### PR TITLE
fix: add GitHub context in reporter and clean-up logging

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,10 +1,10 @@
 {
   "all": true,
   "check-coverage": true,
-  "statements": 95,
-  "branches": 80,
+  "statements": 90,
+  "branches": 85,
   "functions": 100,
-  "lines": 95,
+  "lines": 90,
   "include": [
     "src/**/*.js",
     "src/**/*.cjs"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,3 @@ updates:
         update-types:
           - version-update:semver-minor
           - version-update:semver-patch
-      - dependency-name: chalk

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,16 @@
       "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "chalk": "^4",
         "mocha": "^10",
         "uuid": "^9"
       },
       "devDependencies": {
         "c8": "^8",
+        "chai": "^4",
         "d2l-license-checker": "^4",
         "eslint": "^8",
-        "eslint-config-brightspace": "^1"
+        "eslint-config-brightspace": "^1",
+        "sinon": "^17"
       },
       "engines": {
         "node": ">=20"
@@ -756,6 +757,50 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -994,6 +1039,15 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -1160,6 +1214,24 @@
       ],
       "peer": true
     },
+    "node_modules/chai": {
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
+      "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1173,6 +1245,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -1353,6 +1437,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -2195,6 +2291,15 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
@@ -2895,6 +3000,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3058,6 +3169,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3077,6 +3194,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.1"
       }
     },
     "node_modules/lru-cache": {
@@ -3302,6 +3428,46 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/nise": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.5.tgz",
+      "integrity": "sha512-VJuPIfUFaXNRzETTQEEItTOP8Y171ijr+JLq42wHes3DiryR8vT+1TXQW/Rx8JNUhyYYWyIvjXTU6dOhJcs9Nw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.14",
@@ -3586,6 +3752,30 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
+    "node_modules/path-to-regexp/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -3967,6 +4157,33 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/sinon": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-17.0.1.tgz",
+      "integrity": "sha512-wmwE19Lie0MLT+ZYNpDymasPHUKTaZHUH/pKEubRXIzySv9Atnlw+BUMGCzWgV7b7wO+Hw6f1TEOr0IUnmU8/g==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.1.0",
+        "nise": "^5.1.5",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
@@ -4238,6 +4455,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "repository": "https://github.com/Brightspace/test-reporting-node.git",
   "type": "module",
   "exports": {
+    "./helpers/github.js": "./src/helpers/github.cjs",
     "./reporters/mocha.js": "./src/reporters/mocha.cjs"
   },
   "publishConfig": {
@@ -18,7 +19,7 @@
     "lint:eslint": "eslint . --ext .js,.cjs",
     "fix": "npm run fix:eslint",
     "fix:eslint": "npm run lint:eslint -- --fix",
-    "test": "npm run lint && npm run test:unit",
+    "test": "npm run lint && npm test:unit",
     "test:unit": "c8 mocha"
   },
   "engines": {
@@ -28,14 +29,15 @@
     "/src"
   ],
   "dependencies": {
-    "chalk": "^4",
     "mocha": "^10",
     "uuid": "^9"
   },
   "devDependencies": {
     "c8": "^8",
+    "chai": "^4",
     "d2l-license-checker": "^4",
     "eslint": "^8",
-    "eslint-config-brightspace": "^1"
+    "eslint-config-brightspace": "^1",
+    "sinon": "^17"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:eslint": "eslint . --ext .js,.cjs",
     "fix": "npm run fix:eslint",
     "fix:eslint": "npm run lint:eslint -- --fix",
-    "test": "npm run lint && npm test:unit",
+    "test": "npm run lint && npm run test:unit",
     "test:unit": "c8 mocha"
   },
   "engines": {

--- a/src/helpers/github.cjs
+++ b/src/helpers/github.cjs
@@ -1,0 +1,43 @@
+class GitHubActionsUnavailableError extends Error {
+	constructor() {
+		super('GitHub Actions context unavailable');
+	}
+}
+
+const hasContext = () => {
+	const { env: { GITHUB_ACTIONS } } = process;
+
+	return !!GITHUB_ACTIONS;
+};
+
+const getContext = () => {
+	if (!hasContext()) {
+		throw new GitHubActionsUnavailableError();
+	}
+
+	const { env: {
+		GITHUB_REPOSITORY,
+		GITHUB_WORKFLOW_REF,
+		GITHUB_RUN_ID,
+		GITHUB_RUN_ATTEMPT,
+		GITHUB_HEAD_REF,
+		GITHUB_REF,
+		GITHUB_SHA
+	} } = process;
+	const [owner, repo] = GITHUB_REPOSITORY.split('/');
+	const [workflowPath] = GITHUB_WORKFLOW_REF.split('@');
+	const workflowRegex = new RegExp(`^${owner}/${repo}/.github/workflows/`);
+	const branchRef = GITHUB_HEAD_REF || GITHUB_REF;
+
+	return {
+		githubOrganization: owner,
+		githubRepository: repo,
+		githubWorkflow: workflowPath.replace(workflowRegex, ''),
+		githubRunId: parseInt(GITHUB_RUN_ID, 10),
+		githubRunAttempt: parseInt(GITHUB_RUN_ATTEMPT, 10),
+		gitBranch: branchRef.replace(/^refs\/heads\//i, ''),
+		gitSha: GITHUB_SHA
+	};
+};
+
+module.exports = { getContext, hasContext, GitHubActionsUnavailableError };

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -33,16 +33,19 @@ describe('github', () => {
 			gitBranch: 'test/branch',
 			gitSha: '0000000000000000000000000000000000000000'
 		};
+		const commonEnvironment = {
+			'GITHUB_ACTIONS': '1',
+			'GITHUB_REPOSITORY': 'TestOrganization/test-repository',
+			'GITHUB_WORKFLOW_REF': 'TestOrganization/test-repository/.github/workflows/test-workflow.yml@refs/heads/test/branch',
+			'GITHUB_RUN_ID': '12345',
+			'GITHUB_RUN_ATTEMPT': '1',
+			'GITHUB_SHA': '0000000000000000000000000000000000000000'
+		};
 
 		it('pull request', () => {
 			sandbox.stub(process, 'env').value({
-				'GITHUB_ACTIONS': '1',
-				'GITHUB_REPOSITORY': 'TestOrganization/test-repository',
-				'GITHUB_WORKFLOW_REF': 'TestOrganization/test-repository/.github/workflows/test-workflow.yml@refs/heads/test/branch',
-				'GITHUB_RUN_ID': '12345',
-				'GITHUB_RUN_ATTEMPT': '1',
-				'GITHUB_HEAD_REF': 'test/branch',
-				'GITHUB_SHA': '0000000000000000000000000000000000000000'
+				...commonEnvironment,
+				'GITHUB_HEAD_REF': 'test/branch'
 			});
 
 			const context = getContext();
@@ -52,13 +55,8 @@ describe('github', () => {
 
 		it('branch', () => {
 			sandbox.stub(process, 'env').value({
-				'GITHUB_ACTIONS': '1',
-				'GITHUB_REPOSITORY': 'TestOrganization/test-repository',
-				'GITHUB_WORKFLOW_REF': 'TestOrganization/test-repository/.github/workflows/test-workflow.yml@refs/heads/test/branch',
-				'GITHUB_RUN_ID': '12345',
-				'GITHUB_RUN_ATTEMPT': '1',
-				'GITHUB_REF': 'test/branch',
-				'GITHUB_SHA': '0000000000000000000000000000000000000000'
+				...commonEnvironment,
+				'GITHUB_REF': 'test/branch'
 			});
 
 			const context = getContext();

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -1,0 +1,85 @@
+import { getContext, GitHubActionsUnavailableError, hasContext } from '../src/helpers/github.cjs';
+import { createSandbox } from 'sinon';
+import { expect } from 'chai';
+
+describe('github', () => {
+	let sandbox;
+
+	before(() => sandbox = createSandbox());
+
+	afterEach(() => sandbox.restore());
+
+	describe('has context', () => {
+		it('true', () => {
+			sandbox.stub(process, 'env').value({ 'GITHUB_ACTIONS': '1' });
+
+			expect(hasContext()).to.be.true;
+		});
+
+		it('false', () => {
+			sandbox.stub(process, 'env').value({});
+
+			expect(hasContext()).to.be.false;
+		});
+	});
+
+	describe('get context', () => {
+		const expectedResult = {
+			githubOrganization: 'TestOrganization',
+			githubRepository: 'test-repository',
+			githubWorkflow: 'test-workflow.yml',
+			githubRunId: 12345,
+			githubRunAttempt: 1,
+			gitBranch: 'test/branch',
+			gitSha: '0000000000000000000000000000000000000000'
+		};
+
+		it('pull request', () => {
+			sandbox.stub(process, 'env').value({
+				'GITHUB_ACTIONS': '1',
+				'GITHUB_REPOSITORY': 'TestOrganization/test-repository',
+				'GITHUB_WORKFLOW_REF': 'TestOrganization/test-repository/.github/workflows/test-workflow.yml@refs/heads/test/branch',
+				'GITHUB_RUN_ID': '12345',
+				'GITHUB_RUN_ATTEMPT': '1',
+				'GITHUB_HEAD_REF': 'test/branch',
+				'GITHUB_SHA': '0000000000000000000000000000000000000000'
+			});
+
+			const context = getContext();
+
+			expect(expectedResult).to.deep.eq(context);
+		});
+
+		it('branch', () => {
+			sandbox.stub(process, 'env').value({
+				'GITHUB_ACTIONS': '1',
+				'GITHUB_REPOSITORY': 'TestOrganization/test-repository',
+				'GITHUB_WORKFLOW_REF': 'TestOrganization/test-repository/.github/workflows/test-workflow.yml@refs/heads/test/branch',
+				'GITHUB_RUN_ID': '12345',
+				'GITHUB_RUN_ATTEMPT': '1',
+				'GITHUB_REF': 'test/branch',
+				'GITHUB_SHA': '0000000000000000000000000000000000000000'
+			});
+
+			const context = getContext();
+
+			expect(expectedResult).to.deep.eq(context);
+		});
+
+		describe('fails', () => {
+			it('not in github actions', () => {
+				sandbox.stub(process, 'env').value({});
+
+				try {
+					getContext();
+				} catch (err) {
+					expect(err).instanceOf(GitHubActionsUnavailableError);
+
+					return;
+				}
+
+				throw new Error('failed');
+			});
+		});
+	});
+});


### PR DESCRIPTION
Removes need for `chalk` as well. Will only try to add context if it can be found. Otherwise just emits a warning.