### PR TITLE
fix: add provenance for published package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ env:
   FORCE_COLOR: 3
 permissions:
   contents: read
+  id-token: write
 jobs:
   release:
     name: Release

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "./reporters/mocha.js": "./src/reporters/mocha.cjs"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "license-check": "d2l-license-checker -p",


### PR DESCRIPTION
Adds a nice little green checkmark with provenance information on the npmjs website. See https://docs.npmjs.com/generating-provenance-statements.