### PR TITLE
fix: report options reading for mocha

### DIFF
--- a/src/reporters/mocha.cjs
+++ b/src/reporters/mocha.cjs
@@ -35,7 +35,7 @@ class TestReportingMochaReporter extends Spec {
 		super(runner, options);
 
 		const { stats } = runner;
-		const { reporterOptions: { reportPath } } = options;
+		const { reporterOptions: { reportPath } = {} } = options;
 
 		this._reportPath = reportPath ?? './d2l-test-report.json';
 		this._report = {


### PR DESCRIPTION
![image](https://github.com/Brightspace/test-reporting-node/assets/9043211/5e46a19a-7404-45a8-9d18-145ed8c57b27)
