### PR TITLE
Add test report generation validation

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,3 +1,0 @@
-{
-  "spec": "test/unit/*.test.js"
-}

--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
     "fix:eslint": "npm run lint:eslint -- --fix",
     "test": "run-s lint test:all",
     "test:all": "run-s test:unit test:integration",
-    "test:unit": "mocha test/unit/**/*.test.js",
-    "test:integration": "run-s test:integration:mocha test:integration:playwright",
+    "test:unit": "mocha \"test/unit/**/*.test.js\"",
+    "test:integration": "run-s test:integration:mocha test:integration:playwright test:integration:report-validation",
     "test:integration:mocha": "mocha --config test/integration/configs/mocha.cjs || exit 0",
     "test:integration:playwright": "playwright test --config test/integration/configs/playwright.js || exit 0",
+    "test:integration:report-validation": "mocha test/integration/report-validation.test.js",
     "test:coverage": "c8 npm run test:all"
   },
   "engines": {

--- a/test/integration/report-validation.test.js
+++ b/test/integration/report-validation.test.js
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import { readFile } from 'fs/promises';
+
+describe('validation', () => {
+	it('mocha', async() => {
+		let report = await readFile('./d2l-test-report-mocha.json', 'utf8');
+
+		report = JSON.parse(report);
+
+		expect(report.reportVersion).to.eq(1);
+	});
+
+	it('playwright', async() => {
+		let report = await readFile('./d2l-test-report-playwright.json', 'utf8');
+
+		report = JSON.parse(report);
+
+		expect(report.reportVersion).to.eq(1);
+	});
+});


### PR DESCRIPTION
Doesn't actually do any validation. Just putting the set-up in place. Plan is to move the schema validation helper from the `*-action` repository into here so we can run schema validation and then do some specific value checks.