### PR TITLE
fix: clean-up usage of minimatch

### DIFF
--- a/src/reporters/helpers.cjs
+++ b/src/reporters/helpers.cjs
@@ -1,7 +1,8 @@
-const { relative, sep: platformSeparator, resolve } = require('path');
-const { join } = require('path/posix');
-const { readFileSync, writeFileSync } = require('fs');
-const { type } = require('os');
+const { relative, sep: platformSeparator, resolve } = require('node:path');
+const { join } = require('node:path/posix');
+const { minimatch } = require('minimatch');
+const { readFileSync, writeFileSync } = require('node:fs');
+const { type } = require('node:os');
 
 const defaultReportPath = './d2l-test-report.json';
 const defaultConfigurationPath = './d2l-test-reporting.config.json';
@@ -92,13 +93,13 @@ const getConfiguration = (configurationPath) => {
 	}
 };
 
-const getMetaData = (configuration, callback, location) => {
+const getMetaData = (configuration, location) => {
 	const metadata = {};
 
 	for (const override of configuration.overrides ?? []) {
 		const { pattern, type, tool, experience } = override;
 
-		if (callback(location, pattern)) {
+		if (minimatch(location, pattern)) {
 			metadata.type = type;
 			metadata.tool = tool;
 			metadata.experience = experience;
@@ -114,7 +115,7 @@ const getMetaData = (configuration, callback, location) => {
 	return metadata;
 };
 
-const writeReport = (reportPath, report)=> {
+const writeReport = (reportPath, report) => {
 	writeFileSync(reportPath, JSON.stringify(report, memberPriority), 'utf8');
 };
 

--- a/src/reporters/mocha.cjs
+++ b/src/reporters/mocha.cjs
@@ -1,9 +1,7 @@
-const { reporters: { Base, Spec } } = require('mocha');
+const { reporters: { Base, Spec }, Runner: { constants } } = require('mocha');
 const { hasContext, getContext } = require('../helpers/github.cjs');
 const { getOperatingSystem, makeLocation, getConfiguration, getMetaData, determineReportPath, writeReport } = require('./helpers.cjs');
-const { minimatch } = require('minimatch');
-const { randomUUID } = require('crypto');
-const { Runner: { constants } } = require('mocha');
+const { randomUUID } = require('node:crypto');
 
 const { consoleLog, color } = Base;
 
@@ -87,11 +85,7 @@ class TestReportingMochaReporter extends Spec {
 		values.totalDuration = values.totalDuration ?? 0;
 
 		if (!values.type || !values.tool || !values.experience) {
-			const { type, tool, experience } = getMetaData(
-				this._configuration,
-				minimatch,
-				values.location
-			);
+			const { type, tool, experience } = getMetaData(this._configuration, values.location);
 
 			values.type = values.type ?? type;
 			values.tool = values.tool ?? tool;

--- a/src/reporters/playwright.js
+++ b/src/reporters/playwright.js
@@ -1,8 +1,11 @@
-import { getOperatingSystem, getConfiguration, makeLocation, getMetaData, determineReportPath, writeReport } from './helpers.cjs';
 import { getContext, hasContext } from '../helpers/github.cjs';
+import { createRequire } from 'node:module';
 import { colors } from 'playwright-core/lib/utilsBundle';
-import { minimatch } from 'minimatch';
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
+
+const require = createRequire(import.meta.url);
+
+const { getOperatingSystem, getConfiguration, makeLocation, getMetaData, determineReportPath, writeReport } = require('./helpers.cjs');
 
 const { cyan, red, yellow } = colors;
 
@@ -94,11 +97,7 @@ export default class Reporter {
 		}
 
 		if (!values.type || !values.tool || !values.experience) {
-			const { type, tool, experience } = getMetaData(
-				this._configuration,
-				minimatch,
-				values.location
-			);
+			const { type, tool, experience } = getMetaData(this._configuration, values.location);
 
 			values.type = values.type ?? type;
 			values.tool = values.tool ?? tool;

--- a/test/integration/configs/d2l-test-reporting.config.json
+++ b/test/integration/configs/d2l-test-reporting.config.json
@@ -1,11 +1,11 @@
 {
-  "type": "Integration",
+  "type": "integration",
   "experience": "Test Framework",
   "tool": "Test Reporting",
   "overrides": [
     {
       "pattern": "*/**/mocha-1.test.js",
-      "experience": "Mocha 1 Test Framework",
+      "type": "ui",
       "tool": "Mocha 1 Test Reporting"
     },
     {
@@ -19,6 +19,7 @@
     },
     {
       "pattern": "*/**/playwright-2.test.js",
+      "type": "visual diff",
       "experience": "Playwright 2 Test Framework"
     }
   ]


### PR DESCRIPTION
This fixes the issue with including `minimatch`. Not a huge fan of mixing `commonjs` and `modules` but due to the mocha reporter needing to be `commonjs` it's kind of unavoidable. Might be worth introducing a build step at some point to output something that works for both automatically but fort now this work.