### PR TITLE
fix: move validation over from action

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -2,7 +2,7 @@
   "all": true,
   "check-coverage": true,
   "statements": 90,
-  "branches": 75,
+  "branches": 80,
   "functions": 90,
   "lines": 90,
   "include": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           npm ci
           npx playwright install --with-deps
       - name: Run tests
-        run: npm run test:coverage
+        run: npm run test:all
       - name: Hide outdated comment
         uses: Brightspace/third-party-actions@int128/hide-comment-action
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.16",
       "license": "Apache-2.0",
       "dependencies": {
+        "ajv": "^8",
+        "ajv-formats": "^2",
         "minimatch": "^9",
         "mocha": "^10",
         "playwright-core": "^1"
@@ -444,6 +446,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -468,6 +486,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
@@ -755,19 +779,34 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-colors": {
@@ -1467,9 +1506,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.634",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.634.tgz",
-      "integrity": "sha512-gQNahJfF5AE4MZo+pMSwmnwkzVZ+F4ZGGj4Z/MMddOXVQM0y9OHy6ts3W9SDzAJaiZM3p6eixn5ABCQ+AfXzcQ==",
+      "version": "1.4.635",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.635.tgz",
+      "integrity": "sha512-iu/2D0zolKU3iDGXXxdOzNf72Jnokn+K1IN6Kk4iV6l1Tr2g/qy+mvmtfAiBwZe5S3aB5r92vp+zSZ69scYRrg==",
       "dev": true,
       "peer": true
     },
@@ -1874,6 +1913,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2006,6 +2061,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2123,8 +2184,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3025,10 +3085,9 @@
       "dev": true
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4058,7 +4117,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4188,6 +4246,14 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4927,7 +4993,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "type": "module",
   "exports": {
     "./helpers/github.js": "./src/helpers/github.cjs",
+    "./helpers/report.js": "./src/helpers/report.cjs",
     "./reporters/mocha.js": "./src/reporters/mocha.cjs",
     "./reporters/playwright.js": "./src/reporters/playwright.js"
   },
@@ -22,13 +23,12 @@
     "fix": "npm run fix:eslint",
     "fix:eslint": "npm run lint:eslint -- --fix",
     "test": "run-s lint test:all",
-    "test:all": "run-s test:unit test:integration",
+    "test:all": "c8 run-s test:unit test:integration",
     "test:unit": "mocha \"test/unit/**/*.test.js\"",
     "test:integration": "run-s test:integration:mocha test:integration:playwright test:integration:report-validation",
     "test:integration:mocha": "mocha --config test/integration/configs/mocha.cjs || exit 0",
     "test:integration:playwright": "playwright test --config test/integration/configs/playwright.js || exit 0",
-    "test:integration:report-validation": "mocha test/integration/report-validation.test.js",
-    "test:coverage": "c8 npm run test:all"
+    "test:integration:report-validation": "mocha test/integration/report-validation.test.js"
   },
   "engines": {
     "node": ">=20"
@@ -37,6 +37,8 @@
     "/src"
   ],
   "dependencies": {
+    "ajv": "^8",
+    "ajv-formats": "^2",
     "minimatch": "^9",
     "mocha": "^10",
     "playwright-core": "^1"

--- a/src/helpers/github.cjs
+++ b/src/helpers/github.cjs
@@ -1,8 +1,4 @@
-class GitHubActionsUnavailableError extends Error {
-	constructor() {
-		super('GitHub Actions context unavailable');
-	}
-}
+const { ajv: { errorsText }, validateContextAjv } = require('./schema.cjs');
 
 const hasContext = () => {
 	const { env: { GITHUB_ACTIONS } } = process;
@@ -12,7 +8,7 @@ const hasContext = () => {
 
 const getContext = () => {
 	if (!hasContext()) {
-		throw new GitHubActionsUnavailableError();
+		throw new Error('GitHub context unavailable');
 	}
 
 	const { env: {
@@ -40,4 +36,13 @@ const getContext = () => {
 	};
 };
 
-module.exports = { getContext, hasContext, GitHubActionsUnavailableError };
+const validateContext = (context) => {
+	if (!validateContextAjv(context)) {
+		const { errors } = validateContextAjv;
+		const message = errorsText(errors, { dataVar: 'context' });
+
+		throw new Error(`GitHub context does not conform to schema: ${message}`);
+	}
+};
+
+module.exports = { getContext, hasContext, validateContext };

--- a/src/helpers/report.cjs
+++ b/src/helpers/report.cjs
@@ -1,0 +1,12 @@
+const { ajv: { errorsText }, validateReportAjv } = require('./schema.cjs');
+
+const validateReport = (report) => {
+	if (!validateReportAjv(report)) {
+		const { errors } = validateReportAjv;
+		const message = errorsText(errors, { dataVar: 'report' });
+
+		throw new Error(`Report does not conform to schema: ${message}`);
+	}
+};
+
+module.exports = { validateReport };

--- a/src/helpers/schema.cjs
+++ b/src/helpers/schema.cjs
@@ -1,0 +1,102 @@
+const Ajv = require('ajv');
+const addFormats = require('ajv-formats');
+
+const ajv = new Ajv({ verbose: true });
+
+addFormats(ajv, ['date-time', 'uri', 'uuid']);
+
+const nonEmptyStringPattern = '^(?!\\s).+(?<!\\s)$';
+const gitHubPattern = '[A-Za-z0-9_.-]+';
+const contextProperties = {
+	githubOrganization: { type: 'string', pattern: gitHubPattern },
+	githubRepository: { type: 'string', pattern: gitHubPattern },
+	githubWorkflow: { type: 'string', pattern: nonEmptyStringPattern },
+	githubRunId: { type: 'integer', minimum: 0 },
+	githubRunAttempt: { type: 'integer', minimum: 1 },
+	gitBranch: { type: 'string', pattern: nonEmptyStringPattern },
+	gitSha: { type: 'string', pattern: '([A-Fa-f0-9]{40})' }
+};
+const contextSchema = {
+	type: 'object',
+	properties: contextProperties,
+	required: Object.keys(contextProperties),
+	additionalProperties: true
+};
+const reportSchema = {
+	type: 'object',
+	properties: {
+		reportId: { type: 'string', format: 'uuid' },
+		reportVersion: { type: 'integer', const: 1 },
+		summary: {
+			type: 'object',
+			properties: {
+				...contextProperties,
+				lmsBuild: { type: 'string', pattern: '([0-9]{2}\\.){3}[0-9]{5}' },
+				lmsInstance: { type: 'string', format: 'uri' },
+				operatingSystem: { type: 'string', enum: ['windows', 'linux', 'mac'] },
+				framework: { type: 'string', pattern: nonEmptyStringPattern },
+				started: { type: 'string', format: 'date-time' },
+				totalDuration: { type: 'integer', minimum: 0 },
+				status: { type: 'string', enum: ['passed', 'failed'] },
+				countPassed: { type: 'integer', minimum: 0 },
+				countFailed: { type: 'integer', minimum: 0 },
+				countSkipped: { type: 'integer', minimum: 0 },
+				countFlaky: { type: 'integer', minimum: 0 }
+			},
+			required: [
+				...Object.keys(contextProperties),
+				'operatingSystem',
+				'framework',
+				'started',
+				'totalDuration',
+				'status',
+				'countPassed',
+				'countFailed',
+				'countSkipped',
+				'countFlaky'
+			],
+			additionalProperties: false
+		},
+		details: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					name: { type: 'string', pattern: nonEmptyStringPattern },
+					location: { type: 'string', pattern: nonEmptyStringPattern },
+					started: { type: 'string', format: 'date-time' },
+					duration: { type: 'integer', minimum: 0 },
+					totalDuration: { type: 'integer', minimum: 0 },
+					status: { type: 'string', enum: ['passed', 'failed', 'skipped'] },
+					tool: { type: 'string', pattern: nonEmptyStringPattern },
+					experience: { type: 'string', pattern: nonEmptyStringPattern },
+					type: { type: 'string', pattern: nonEmptyStringPattern },
+					browser: { type: 'string', enum: ['chromium', 'firefox', 'webkit'] },
+					retries: { type: 'integer', minimum: 0 }
+				},
+				required: [
+					'name',
+					'location',
+					'started',
+					'duration',
+					'totalDuration',
+					'status',
+					'retries'
+				],
+				additionalProperties: false
+			}
+		}
+	},
+	required: [
+		'reportId',
+		'reportVersion',
+		'summary',
+		'details'
+	],
+	additionalProperties: false
+};
+
+const validateContextAjv = ajv.compile(contextSchema);
+const validateReportAjv = ajv.compile(reportSchema);
+
+module.exports = { ajv, validateContextAjv, validateReportAjv };

--- a/src/reporters/playwright.js
+++ b/src/reporters/playwright.js
@@ -1,10 +1,10 @@
-import { getContext, hasContext } from '../helpers/github.cjs';
 import { createRequire } from 'node:module';
 import { colors } from 'playwright-core/lib/utilsBundle';
 import { randomUUID } from 'node:crypto';
 
 const require = createRequire(import.meta.url);
 
+const { getContext, hasContext } = require('../helpers/github.cjs');
 const { getOperatingSystem, getConfiguration, makeLocation, getMetaData, determineReportPath, writeReport } = require('./helpers.cjs');
 
 const { cyan, red, yellow } = colors;

--- a/test/integration/report-validation.test.js
+++ b/test/integration/report-validation.test.js
@@ -1,13 +1,31 @@
-import { expect } from 'chai';
-import { readFile } from 'fs/promises';
+import { hasContext } from '../../src/helpers/github.cjs';
+import { readFile } from 'node:fs/promises';
+import { validateReport } from '../../src/helpers/report.cjs';
 
-describe('validation', () => {
+const dummyContext = {
+	githubOrganization: 'TestOrganization',
+	githubRepository: 'test-repository',
+	githubWorkflow: 'test-workflow.yml',
+	githubRunId: 12345,
+	githubRunAttempt: 1,
+	gitBranch: 'test/branch',
+	gitSha: '0000000000000000000000000000000000000000'
+};
+
+describe('report validation', () => {
 	it('mocha', async() => {
 		let report = await readFile('./d2l-test-report-mocha.json', 'utf8');
 
 		report = JSON.parse(report);
 
-		expect(report.reportVersion).to.eq(1);
+		if (!hasContext()) {
+			report.summary = {
+				...report.summary,
+				...dummyContext
+			};
+		}
+
+		validateReport(report);
 	});
 
 	it('playwright', async() => {
@@ -15,6 +33,13 @@ describe('validation', () => {
 
 		report = JSON.parse(report);
 
-		expect(report.reportVersion).to.eq(1);
+		if (!hasContext()) {
+			report.summary = {
+				...report.summary,
+				...dummyContext
+			};
+		}
+
+		validateReport(report);
 	});
 });

--- a/test/unit/github.test.js
+++ b/test/unit/github.test.js
@@ -1,4 +1,4 @@
-import { getContext, GitHubActionsUnavailableError, hasContext } from '../../src/helpers/github.cjs';
+import { getContext, hasContext } from '../../src/helpers/github.cjs';
 import { createSandbox } from 'sinon';
 import { expect } from 'chai';
 
@@ -71,7 +71,7 @@ describe('github', () => {
 				try {
 					getContext();
 				} catch (err) {
-					expect(err).instanceOf(GitHubActionsUnavailableError);
+					expect(err.message).to.eq('GitHub context unavailable');
 
 					return;
 				}


### PR DESCRIPTION
This moves the validation over from [Brightspace/test-reporting-action](https://github.com/Brightspace/test-reporting-action) to here so we can use it for report generation validation as well as have 1 spot for report schema and format helpers. Once this is in I'll move the action over to using the new helpers. I still want to rework this to be a bit more organized but this at least get's it all in 1 spot. Partially takes care of https://github.com/Brightspace/test-reporting-action/issues/53.