### PR TITLE
fix: flaky count

### DIFF
--- a/src/reporters/mocha.cjs
+++ b/src/reporters/mocha.cjs
@@ -123,10 +123,13 @@ class TestReportingMochaReporter extends Spec {
 	_onRunEnd(stats) {
 		this._report.summary.totalDuration = stats.duration;
 		this._report.summary.status = stats.failures !== 0 ? 'failed' : 'passed';
-		this._report.summary.countPassed = stats.passes;
+
+		const flakyCount = this._testsFlaky.size;
+
+		this._report.summary.countPassed = stats.passes - flakyCount;
 		this._report.summary.countFailed = stats.failures;
 		this._report.summary.countSkipped = stats.pending;
-		this._report.summary.countFlaky = this._testsFlaky.size;
+		this._report.summary.countFlaky = flakyCount;
 		this._report.details = [...this._tests].map(([name, values]) => ({ name, ...values }));
 
 		try {

--- a/src/reporters/playwright.js
+++ b/src/reporters/playwright.js
@@ -124,10 +124,10 @@ export default class Reporter {
 			values.totalDuration = Math.round(values.totalDuration);
 
 			if (values.status === 'passed') {
-				countPassed++;
-
 				if (values.retries !== 0) {
 					countFlaky++;
+				} else {
+					countPassed++;
 				}
 			} else if (values.status === 'failed') {
 				countFailed++;


### PR DESCRIPTION
This doesn't count flaky tests as passed. Keeps the data consistent with playwright and makes it easier to understand overall test counts.