### PR TITLE
fix: add workaround for getting project data

### DIFF
--- a/src/reporters/helpers.cjs
+++ b/src/reporters/helpers.cjs
@@ -93,7 +93,7 @@ const getConfiguration = (configurationPath) => {
 	}
 };
 
-const getMetaData = (configuration, location) => {
+const getReportOptions = (configuration, location) => {
 	const metadata = {};
 
 	for (const override of configuration.overrides ?? []) {
@@ -124,6 +124,6 @@ module.exports = {
 	makeLocation,
 	determineReportPath,
 	getConfiguration,
-	getMetaData,
+	getReportOptions,
 	writeReport
 };

--- a/src/reporters/mocha.cjs
+++ b/src/reporters/mocha.cjs
@@ -1,6 +1,6 @@
 const { reporters: { Base, Spec }, Runner: { constants } } = require('mocha');
 const { hasContext, getContext } = require('../helpers/github.cjs');
-const { getOperatingSystem, makeLocation, getConfiguration, getMetaData, determineReportPath, writeReport } = require('./helpers.cjs');
+const { getOperatingSystem, makeLocation, getConfiguration, getReportOptions, determineReportPath, writeReport } = require('./helpers.cjs');
 const { randomUUID } = require('node:crypto');
 
 const { consoleLog, color } = Base;
@@ -85,7 +85,7 @@ class TestReportingMochaReporter extends Spec {
 		values.totalDuration = values.totalDuration ?? 0;
 
 		if (!values.type || !values.tool || !values.experience) {
-			const { type, tool, experience } = getMetaData(this._configuration, values.location);
+			const { type, tool, experience } = getReportOptions(this._configuration, values.location);
 
 			values.type = values.type ?? type;
 			values.tool = values.tool ?? tool;

--- a/src/reporters/playwright.js
+++ b/src/reporters/playwright.js
@@ -61,7 +61,6 @@ export default class Reporter {
 
 	onBegin(config, suite) {
 		this._hasTests = suite.allTests().length !== 0;
-		this._config = config;
 
 		if (!this._hasTests) {
 			return;

--- a/src/reporters/playwright.js
+++ b/src/reporters/playwright.js
@@ -5,7 +5,7 @@ import { randomUUID } from 'node:crypto';
 const require = createRequire(import.meta.url);
 
 const { getContext, hasContext } = require('../helpers/github.cjs');
-const { getOperatingSystem, getConfiguration, makeLocation, getMetaData, determineReportPath, writeReport } = require('./helpers.cjs');
+const { getOperatingSystem, getConfiguration, makeLocation, getReportOptions, determineReportPath, writeReport } = require('./helpers.cjs');
 
 const { cyan, red, yellow } = colors;
 
@@ -103,7 +103,7 @@ export default class Reporter {
 		}
 
 		if (!values.type || !values.tool || !values.experience) {
-			const { type, tool, experience } = getMetaData(this._configuration, values.location);
+			const { type, tool, experience } = getReportOptions(this._configuration, values.location);
 
 			values.type = values.type ?? type;
 			values.tool = values.tool ?? tool;


### PR DESCRIPTION
Get's us closer to being able to use the `merge-reports` workflow for `playwright`. Right now this still fails to get `defaultBrowserType` due to https://github.com/microsoft/playwright/issues/29174.