### PR TITLE
fix: clean-up some naming

### DIFF
--- a/src/reporters/helpers.cjs
+++ b/src/reporters/helpers.cjs
@@ -6,7 +6,7 @@ const { type } = require('node:os');
 
 const defaultReportPath = './d2l-test-report.json';
 const defaultConfigurationPath = './d2l-test-reporting.config.json';
-const memberPriority = [
+const reportMemberPriority = [
 	'reportId',
 	'reportVersion',
 	'summary',
@@ -59,37 +59,37 @@ const makeLocation = (filePath) => {
 	return join(...pathParts);
 };
 
-const determineReportPath = (reportPath) => {
-	return resolve(reportPath ?? defaultReportPath);
+const determineReportPath = (path) => {
+	return resolve(path ?? defaultReportPath);
 };
 
-const getConfiguration = (configurationPath) => {
-	if (configurationPath) {
-		configurationPath = resolve(configurationPath);
+const getReportConfiguration = (path) => {
+	if (path) {
+		path = resolve(path);
 
 		try {
-			const configurationData = readFileSync(configurationPath, 'utf8');
+			const contents = readFileSync(path, 'utf8');
 
-			return JSON.parse(configurationData);
+			return JSON.parse(contents);
 		} catch {
-			throw new Error(`Unable to read/parse configuration at path ${configurationPath}`);
+			throw new Error(`Unable to read/parse configuration at path ${path}`);
 		}
 	}
 
-	configurationPath = resolve(defaultConfigurationPath);
+	path = resolve(defaultConfigurationPath);
 
-	let configurationData;
+	let contents;
 
 	try {
-		configurationData = readFileSync(configurationPath, 'utf8');
+		contents = readFileSync(path, 'utf8');
 	} catch {
 		return {};
 	}
 
 	try {
-		return JSON.parse(configurationData);
+		return JSON.parse(contents);
 	} catch {
-		throw new Error(`Unable to read/parse configuration at path ${defaultConfigurationPath}`);
+		throw new Error(`Unable to read/parse configuration at path ${path}`);
 	}
 };
 
@@ -116,14 +116,14 @@ const getReportOptions = (configuration, location) => {
 };
 
 const writeReport = (reportPath, report) => {
-	writeFileSync(reportPath, JSON.stringify(report, memberPriority), 'utf8');
+	writeFileSync(reportPath, JSON.stringify(report, reportMemberPriority), 'utf8');
 };
 
 module.exports = {
 	getOperatingSystem,
 	makeLocation,
 	determineReportPath,
-	getConfiguration,
+	getReportConfiguration,
 	getReportOptions,
 	writeReport
 };

--- a/src/reporters/mocha.cjs
+++ b/src/reporters/mocha.cjs
@@ -1,6 +1,6 @@
 const { reporters: { Base, Spec }, Runner: { constants } } = require('mocha');
 const { hasContext, getContext } = require('../helpers/github.cjs');
-const { getOperatingSystem, makeLocation, getConfiguration, getReportOptions, determineReportPath, writeReport } = require('./helpers.cjs');
+const { getOperatingSystem, makeLocation, getReportConfiguration, getReportOptions, determineReportPath, writeReport } = require('./helpers.cjs');
 const { randomUUID } = require('node:crypto');
 
 const { consoleLog, color } = Base;
@@ -31,9 +31,9 @@ class TestReportingMochaReporter extends Spec {
 		super(runner, options);
 
 		const { stats } = runner;
-		const { reporterOptions: { reportPath, configurationPath } = {} } = options;
+		const { reporterOptions: { reportPath, reportConfigurationPath } = {} } = options;
 
-		this._configuration = getConfiguration(configurationPath);
+		this._reportConfiguration = getReportConfiguration(reportConfigurationPath);
 		this._reportPath = determineReportPath(reportPath);
 		this._report = {
 			reportId: randomUUID(),
@@ -85,7 +85,7 @@ class TestReportingMochaReporter extends Spec {
 		values.totalDuration = values.totalDuration ?? 0;
 
 		if (!values.type || !values.tool || !values.experience) {
-			const { type, tool, experience } = getReportOptions(this._configuration, values.location);
+			const { type, tool, experience } = getReportOptions(this._reportConfiguration, values.location);
 
 			values.type = values.type ?? type;
 			values.tool = values.tool ?? tool;

--- a/src/reporters/playwright.js
+++ b/src/reporters/playwright.js
@@ -5,7 +5,7 @@ import { randomUUID } from 'node:crypto';
 const require = createRequire(import.meta.url);
 
 const { getContext, hasContext } = require('../helpers/github.cjs');
-const { getOperatingSystem, getConfiguration, makeLocation, getReportOptions, determineReportPath, writeReport } = require('./helpers.cjs');
+const { getOperatingSystem, getReportConfiguration, makeLocation, getReportOptions, determineReportPath, writeReport } = require('./helpers.cjs');
 
 const { cyan, red, yellow } = colors;
 
@@ -45,9 +45,9 @@ const logWarn = (message) => console.log(yellow(`\n${message}\n`));
 const logError = (message) => console.log(red(`\n${message}\n`));
 
 export default class Reporter {
-	constructor({ reportPath, configurationPath } = {}) {
-		this._configuration = getConfiguration(configurationPath);
+	constructor({ reportPath, reportConfigurationPath } = {}) {
 		this._reportPath = determineReportPath(reportPath);
+		this._reportConfiguration = getReportConfiguration(reportConfigurationPath);
 		this._report = {
 			reportId: randomUUID(),
 			reportVersion: 1,
@@ -103,7 +103,7 @@ export default class Reporter {
 		}
 
 		if (!values.type || !values.tool || !values.experience) {
-			const { type, tool, experience } = getReportOptions(this._configuration, values.location);
+			const { type, tool, experience } = getReportOptions(this._reportConfiguration, values.location);
 
 			values.type = values.type ?? type;
 			values.tool = values.tool ?? tool;

--- a/test/integration/configs/mocha.cjs
+++ b/test/integration/configs/mocha.cjs
@@ -4,6 +4,6 @@ module.exports = {
 	reporter: 'src/reporters/mocha.cjs',
 	'reporter-option': [
 		'reportPath=./d2l-test-report-mocha.json',
-		'configurationPath=./test/integration/configs/d2l-test-reporting.config.json'
+		'reportConfigurationPath=./test/integration/configs/d2l-test-reporting.config.json'
 	]
 };

--- a/test/integration/configs/playwright.js
+++ b/test/integration/configs/playwright.js
@@ -2,7 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 
 const playwrightReporterOptions = {
 	reportPath: './d2l-test-report-playwright.json',
-	configurationPath: './test/integration/configs/d2l-test-reporting.config.json'
+	reportConfigurationPath: './test/integration/configs/d2l-test-reporting.config.json'
 };
 
 export default defineConfig({


### PR DESCRIPTION
Makes some stuff more consistent. Shouldn't affect downstreams since they all use defaults.