### PR TITLE
Add example of playwright global setup/teardown to tests

### DIFF
--- a/test/integration/data/config/playwright.js
+++ b/test/integration/data/config/playwright.js
@@ -19,18 +19,30 @@ export default defineConfig({
 	testDir: '../',
 	testMatch: 'playwright-*.test.js',
 	use: deviceTypeChrome,
+	globalSetup: '../playwright.global.setup.js',
+	globalTeardown: '../playwright.global.teardown.js',
 	projects: [{
-		name: 'chromium'
+		name: 'setup',
+		testMatch: 'playwright.setup.js',
+		teardown: 'teardown'
+	}, {
+		name: 'teardown',
+		testMatch: 'playwright.teardown.js'
+	}, {
+		name: 'chromium',
+		dependencies: ['setup']
 	}, {
 		name: 'firefox',
 		testMatch: 'playwright-2.test.js',
 		use: deviceTypeFirefox,
+		dependencies: ['setup'],
 		metadata: {
 			browserType: deviceTypeFirefox.defaultBrowserType
 		}
 	}, {
 		name: 'webkit',
 		use: deviceTypeSafari,
+		dependencies: ['setup'],
 		metadata: {
 			browserType: deviceTypeSafari.defaultBrowserType
 		}

--- a/test/integration/data/playwright.global.setup.js
+++ b/test/integration/data/playwright.global.setup.js
@@ -1,0 +1,3 @@
+export default () => {
+	console.log('global setup'); // eslint-disable-line no-console
+};

--- a/test/integration/data/playwright.global.teardown.js
+++ b/test/integration/data/playwright.global.teardown.js
@@ -1,0 +1,3 @@
+export default () => {
+	console.log('global teardown');// eslint-disable-line no-console
+};

--- a/test/integration/data/playwright.setup.js
+++ b/test/integration/data/playwright.setup.js
@@ -1,0 +1,5 @@
+import { test as setup } from '@playwright/test';
+
+setup('setup', async() => {
+
+});

--- a/test/integration/data/playwright.teardown.js
+++ b/test/integration/data/playwright.teardown.js
@@ -1,0 +1,5 @@
+import { test as teardown } from '@playwright/test';
+
+teardown('teardown', async() => {
+
+});

--- a/test/integration/report-validation.test.js
+++ b/test/integration/report-validation.test.js
@@ -97,12 +97,21 @@ const partialReportPlaywright = {
 	summary: {
 		status: 'failed',
 		framework: 'playwright',
-		countPassed: 5,
+		countPassed: 7,
 		countFailed: 5,
 		countSkipped: 5,
 		countFlaky: 5
 	},
 	details: [{
+		name: '[setup] > setup',
+		status: 'passed',
+		location: 'test/integration/data/playwright.setup.js',
+		browser: 'chromium',
+		tool: 'Test Reporting',
+		experience: 'Test Framework',
+		type: 'integration',
+		retries: 0
+	}, {
 		name: '[chromium] > reporter tests 1 > skipped test',
 		status: 'skipped',
 		location: 'test/integration/data/playwright-1.test.js',
@@ -121,6 +130,15 @@ const partialReportPlaywright = {
 		type: 'visual diff',
 		retries: 0
 	}, {
+		name: '[firefox] > reporter tests 2 > skipped test',
+		status: 'skipped',
+		location: 'test/integration/data/playwright-2.test.js',
+		browser: 'firefox',
+		tool: 'Test Reporting',
+		experience: 'Playwright 2 Test Framework',
+		type: 'visual diff',
+		retries: 0
+	}, {
 		name: '[chromium] > reporter tests 1 > test',
 		status: 'passed',
 		location: 'test/integration/data/playwright-1.test.js',
@@ -128,6 +146,15 @@ const partialReportPlaywright = {
 		tool: 'Playwright 1 Test Reporting',
 		experience: 'Playwright 1 Test Framework',
 		type: 'integration',
+		retries: 0
+	}, {
+		name: '[chromium] > reporter tests 2 > test',
+		status: 'passed',
+		location: 'test/integration/data/playwright-2.test.js',
+		browser: 'chromium',
+		tool: 'Test Reporting',
+		experience: 'Playwright 2 Test Framework',
+		type: 'visual diff',
 		retries: 0
 	}, {
 		name: '[chromium] > reporter tests 1 > failed test',
@@ -139,22 +166,22 @@ const partialReportPlaywright = {
 		type: 'integration',
 		retries: 3
 	}, {
-		name: '[chromium] > reporter tests 2 > test',
+		name: '[firefox] > reporter tests 2 > test',
 		status: 'passed',
-		location: 'test/integration/data/playwright-2.test.js',
-		browser: 'chromium',
-		tool: 'Test Reporting',
-		experience: 'Playwright 2 Test Framework',
-		type: 'visual diff',
-		retries: 0
-	}, {
-		name: '[firefox] > reporter tests 2 > skipped test',
-		status: 'skipped',
 		location: 'test/integration/data/playwright-2.test.js',
 		browser: 'firefox',
 		tool: 'Test Reporting',
 		experience: 'Playwright 2 Test Framework',
 		type: 'visual diff',
+		retries: 0
+	}, {
+		name: '[webkit] > reporter tests 1 > skipped test',
+		status: 'skipped',
+		location: 'test/integration/data/playwright-1.test.js',
+		browser: 'webkit',
+		tool: 'Playwright 1 Test Reporting',
+		experience: 'Playwright 1 Test Framework',
+		type: 'integration',
 		retries: 0
 	}, {
 		name: '[chromium] > reporter tests 2 > failed test',
@@ -166,15 +193,6 @@ const partialReportPlaywright = {
 		type: 'visual diff',
 		retries: 3
 	}, {
-		name: '[firefox] > reporter tests 2 > test',
-		status: 'passed',
-		location: 'test/integration/data/playwright-2.test.js',
-		browser: 'firefox',
-		tool: 'Test Reporting',
-		experience: 'Playwright 2 Test Framework',
-		type: 'visual diff',
-		retries: 0
-	}, {
 		name: '[firefox] > reporter tests 2 > failed test',
 		status: 'failed',
 		location: 'test/integration/data/playwright-2.test.js',
@@ -184,14 +202,23 @@ const partialReportPlaywright = {
 		type: 'visual diff',
 		retries: 3
 	}, {
-		name: '[chromium] > reporter tests 2 > flaky test',
+		name: '[webkit] > reporter tests 1 > test',
 		status: 'passed',
-		location: 'test/integration/data/playwright-2.test.js',
-		browser: 'chromium',
-		tool: 'Test Reporting',
-		experience: 'Playwright 2 Test Framework',
-		type: 'visual diff',
-		retries: 2
+		location: 'test/integration/data/playwright-1.test.js',
+		browser: 'webkit',
+		tool: 'Playwright 1 Test Reporting',
+		experience: 'Playwright 1 Test Framework',
+		type: 'integration',
+		retries: 0
+	}, {
+		name: '[webkit] > reporter tests 1 > failed test',
+		status: 'failed',
+		location: 'test/integration/data/playwright-1.test.js',
+		browser: 'webkit',
+		tool: 'Playwright 1 Test Reporting',
+		experience: 'Playwright 1 Test Framework',
+		type: 'integration',
+		retries: 3
 	}, {
 		name: '[chromium] > reporter tests 1 > flaky test',
 		status: 'passed',
@@ -202,23 +229,23 @@ const partialReportPlaywright = {
 		type: 'integration',
 		retries: 2
 	}, {
-		name: '[webkit] > reporter tests 1 > skipped test',
-		status: 'skipped',
-		location: 'test/integration/data/playwright-1.test.js',
-		browser: 'webkit',
-		tool: 'Playwright 1 Test Reporting',
-		experience: 'Playwright 1 Test Framework',
-		type: 'integration',
-		retries: 0
+		name: '[chromium] > reporter tests 2 > flaky test',
+		status: 'passed',
+		location: 'test/integration/data/playwright-2.test.js',
+		browser: 'chromium',
+		tool: 'Test Reporting',
+		experience: 'Playwright 2 Test Framework',
+		type: 'visual diff',
+		retries: 2
 	}, {
-		name: '[webkit] > reporter tests 1 > test',
+		name: '[webkit] > reporter tests 1 > flaky test',
 		status: 'passed',
 		location: 'test/integration/data/playwright-1.test.js',
 		browser: 'webkit',
 		tool: 'Playwright 1 Test Reporting',
 		experience: 'Playwright 1 Test Framework',
 		type: 'integration',
-		retries: 0
+		retries: 2
 	}, {
 		name: '[webkit] > reporter tests 2 > skipped test',
 		status: 'skipped',
@@ -238,15 +265,6 @@ const partialReportPlaywright = {
 		type: 'visual diff',
 		retries: 2
 	}, {
-		name: '[webkit] > reporter tests 1 > failed test',
-		status: 'failed',
-		location: 'test/integration/data/playwright-1.test.js',
-		browser: 'webkit',
-		tool: 'Playwright 1 Test Reporting',
-		experience: 'Playwright 1 Test Framework',
-		type: 'integration',
-		retries: 3
-	}, {
 		name: '[webkit] > reporter tests 2 > test',
 		status: 'passed',
 		location: 'test/integration/data/playwright-2.test.js',
@@ -265,15 +283,6 @@ const partialReportPlaywright = {
 		type: 'visual diff',
 		retries: 3
 	}, {
-		name: '[webkit] > reporter tests 1 > flaky test',
-		status: 'passed',
-		location: 'test/integration/data/playwright-1.test.js',
-		browser: 'webkit',
-		tool: 'Playwright 1 Test Reporting',
-		experience: 'Playwright 1 Test Framework',
-		type: 'integration',
-		retries: 2
-	}, {
 		name: '[webkit] > reporter tests 2 > flaky test',
 		status: 'passed',
 		location: 'test/integration/data/playwright-2.test.js',
@@ -282,6 +291,15 @@ const partialReportPlaywright = {
 		experience: 'Playwright 2 Test Framework',
 		type: 'visual diff',
 		retries: 2
+	}, {
+		name: '[teardown] > teardown',
+		status: 'passed',
+		location: 'test/integration/data/playwright.teardown.js',
+		browser: 'chromium',
+		tool: 'Test Reporting',
+		experience: 'Test Framework',
+		type: 'integration',
+		retries: 0
 	}]
 };
 const partialReportWebTestRunner = {


### PR DESCRIPTION
Adds examples of both options laid out [here](https://playwright.dev/docs/test-global-setup-teardown). The first option using `dependencies` results in additional "fake" tests in the output. Using option 2 does not have this problem. There doesn't seem to be a nice way to detect option 1 and remove those tests from the output.