### PR TITLE
fix: add report configuration schema and improve error messaging

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -2,7 +2,7 @@
   "all": true,
   "check-coverage": true,
   "statements": 90,
-  "branches": 75,
+  "branches": 70,
   "functions": 90,
   "lines": 90,
   "include": [

--- a/src/helpers/github.cjs
+++ b/src/helpers/github.cjs
@@ -1,4 +1,4 @@
-const { ajv: { errorsText }, validateContextLooseAjv, validateContextStrictAjv } = require('./schema.cjs');
+const { formatErrorAjv, validateContextLooseAjv, validateContextStrictAjv } = require('./schema.cjs');
 
 const hasContext = () => {
 	const { env: { GITHUB_ACTIONS } } = process;
@@ -43,9 +43,8 @@ const validateContext = (context, strict = false) => {
 
 	if (!validateContextAjv(context)) {
 		const { errors } = validateContextAjv;
-		const message = errorsText(errors, { dataVar: 'context' });
 
-		throw new Error(`GitHub context does not conform to schema: ${message}`);
+		throw new Error(formatErrorAjv('github context', errors));
 	}
 };
 

--- a/src/helpers/report.cjs
+++ b/src/helpers/report.cjs
@@ -1,11 +1,10 @@
-const { ajv: { errorsText }, validateReportAjv } = require('./schema.cjs');
+const { formatErrorAjv, validateReportAjv } = require('./schema.cjs');
 
 const validateReport = (report) => {
 	if (!validateReportAjv(report)) {
 		const { errors } = validateReportAjv;
-		const message = errorsText(errors, { dataVar: 'report' });
 
-		throw new Error(`Report does not conform to schema: ${message}`);
+		throw new Error(formatErrorAjv('report', errors));
 	}
 };
 

--- a/test/unit/github.test.js
+++ b/test/unit/github.test.js
@@ -97,7 +97,7 @@ describe('github', () => {
 			it('strict with extra properties', () => {
 				const wrapper = () => validateContext(validContextExtraProperties, true);
 
-				expect(wrapper).to.throw('GitHub context does not conform to schema');
+				expect(wrapper).to.throw('github context does not conform to schema');
 			});
 		});
 	});

--- a/test/unit/report.test.js
+++ b/test/unit/report.test.js
@@ -61,7 +61,7 @@ describe('report', () => {
 			it('invalid', () => {
 				const wrapper = () => validateReport({});
 
-				expect(wrapper).to.throw('Report does not conform to schema');
+				expect(wrapper).to.throw('report does not conform to schema');
 			});
 
 			it('extra properties', () => {
@@ -72,7 +72,7 @@ describe('report', () => {
 
 				const wrapper = () => validateReport(extraProperties);
 
-				expect(wrapper).to.throw('Report does not conform to schema');
+				expect(wrapper).to.throw('report does not conform to schema');
 			});
 		});
 	});


### PR DESCRIPTION
This adds better error messages as well as schema validation for report configuration files. The configs must result in all combinations containing a version of `type`, `test` and `experience`. As an example the following config is not valid since there is no fallback for `tool` and it's not defined in the override so the resulting taxonomy is incomplete.
```json
{
  "experience": "Test Framework",
  "type": "integration",
  "overrides": [
    {
      "pattern": "*/**/mocha-1.test.js",
      "type": "ui",
    }
  ]
}
```
The error messaging isn't perfect but it's good enough for our purposes for now. Will product stuff like the below.
```
Error: report does not conform to schema
Details: the string at '/details/0/name' must match pattern "^(?!\s).+(?<!\s)$"
Current value: "test suite > flaky test "
```
It gives a bit more context. Resolves #91 and resolves #55.