### PR TITLE
fix: add ability to ignore files for report

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2226,9 +2226,9 @@
       "peer": true
     },
     "node_modules/chai": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.0.3.tgz",
-      "integrity": "sha512-wKGCtYv2kVY5WEjKqQ3fSIZWtTFveZCtzinhTZbx3/trVkxefiwovhpU9kRVCwxvKKCEjTWXPdM1/T7zPoDgow==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.0.tgz",
+      "integrity": "sha512-kDZ7MZyM6Q1DhR9jy7dalKohXQ2yrlXkk59CR52aRKxJrobmlBNqnFQxX9xOX8w+4mz8SYlKJa/7D7ddltFXCw==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^2.0.1",

--- a/src/helpers/schema.cjs
+++ b/src/helpers/schema.cjs
@@ -213,6 +213,11 @@ const reportConfigurationSchema = {
 	unevaluatedProperties: false,
 	$ref: '#/$defs/taxonomyObject',
 	properties: {
+		ignorePatterns: {
+			type: 'array',
+			minItems: 1,
+			items: { $ref: '/testReporting/nonEmptyUnpaddedString' }
+		},
 		overrides: {
 			type: 'array',
 			minItems: 1,

--- a/src/reporters/helpers.cjs
+++ b/src/reporters/helpers.cjs
@@ -104,7 +104,7 @@ const getReportConfiguration = (path) => {
 	return reportConfiguration;
 };
 
-const getReportOptions = (configuration, location) => {
+const getReportTaxonomy = (configuration, location) => {
 	const { overrides } = configuration;
 	const metadata = {};
 
@@ -127,6 +127,18 @@ const getReportOptions = (configuration, location) => {
 	return metadata;
 };
 
+const ignorePattern = (configuration, location) => {
+	const { ignorePatterns } = configuration;
+
+	for (const ignorePattern of ignorePatterns ?? []) {
+		if (minimatch(location, ignorePattern)) {
+			return true;
+		}
+	}
+
+	return false;
+};
+
 const writeReport = (reportPath, report) => {
 	writeFileSync(reportPath, JSON.stringify(report, reportMemberPriority), 'utf8');
 };
@@ -136,6 +148,7 @@ module.exports = {
 	makeLocation,
 	determineReportPath,
 	getReportConfiguration,
-	getReportOptions,
+	getReportTaxonomy,
+	ignorePattern,
 	writeReport
 };

--- a/src/reporters/web-test-runner.js
+++ b/src/reporters/web-test-runner.js
@@ -1,4 +1,4 @@
-import { determineReportPath, getOperatingSystem, getReportConfiguration, getReportOptions, makeLocation, writeReport } from './helpers.cjs';
+import { determineReportPath, ignorePattern, getOperatingSystem, getReportConfiguration, getReportTaxonomy, makeLocation, writeReport } from './helpers.cjs';
 import { getContext, hasContext } from '../helpers/github.cjs';
 import { randomUUID } from 'crypto';
 
@@ -32,9 +32,14 @@ export function reporter({ reportPath, reportConfigurationPath, verbose } = {}) 
 
 	const collectTests = (session, prefix, tests) => {
 		const { browser, testFile } = session;
-		const browserName = browser.name.toLowerCase();
 		const location = makeLocation(testFile);
-		const { type, tool, experience } = getReportOptions(reportConfiguration, location);
+
+		if (ignorePattern(reportConfiguration, location)) {
+			return [];
+		}
+
+		const browserName = browser.name.toLowerCase();
+		const { type, tool, experience } = getReportTaxonomy(reportConfiguration, location);
 		const flattened = [];
 
 		for (const test of tests) {

--- a/test/integration/data/config/d2l-test-reporting.json
+++ b/test/integration/data/config/d2l-test-reporting.json
@@ -2,33 +2,40 @@
   "type": "integration",
   "experience": "Test Framework",
   "tool": "Test Reporting",
+  "ignorePatterns": [
+    "**/mocha-3.test.js",
+    "**/playwright-3.test.js",
+    "**/playwright.setup.js",
+    "**/playwright.teardown.js",
+    "**/web-test-runner-3.test.js"
+  ],
   "overrides": [
     {
-      "pattern": "*/**/mocha-1.test.js",
+      "pattern": "**/mocha-1.test.js",
       "type": "ui",
       "tool": "Mocha 1 Test Reporting"
     },
     {
-      "pattern": "*/**/mocha-2.test.js",
+      "pattern": "**/mocha-2.test.js",
       "experience": "Mocha 2 Test Framework"
     },
     {
-      "pattern": "*/**/playwright-1.test.js",
+      "pattern": "**/playwright-1.test.js",
       "experience": "Playwright 1 Test Framework",
       "tool": "Playwright 1 Test Reporting"
     },
     {
-      "pattern": "*/**/playwright-2.test.js",
+      "pattern": "**/playwright-2.test.js",
       "type": "visual diff",
       "experience": "Playwright 2 Test Framework"
     },
     {
-      "pattern": "*/**/web-test-runner-1.test.js",
+      "pattern": "**/web-test-runner-1.test.js",
       "experience": "WebTestRunner 1 Test Framework",
       "tool": "WebTestRunner 1 Test Reporting"
     },
     {
-      "pattern": "*/**/web-test-runner-2.test.js",
+      "pattern": "**/web-test-runner-2.test.js",
       "type": "accessibility",
       "experience": "WebTestRunner 2 Test Framework"
     }

--- a/test/integration/data/mocha-3.test.js
+++ b/test/integration/data/mocha-3.test.js
@@ -1,0 +1,23 @@
+const delay = () => {
+	return new Promise(resolve => setTimeout(resolve, 250));
+};
+
+describe('reporter tests 3', () => {
+	let count = 0;
+
+	it('test', () => { });
+
+	it.skip('skipped test', () => { });
+
+	it('flaky test', async() => {
+		if (count < 2) {
+			await delay();
+
+			count++;
+
+			throw new Error('flaky test failure');
+		}
+	});
+
+	it('failed test', () => { throw new Error('fail'); });
+});

--- a/test/integration/data/playwright-3.test.js
+++ b/test/integration/data/playwright-3.test.js
@@ -1,0 +1,22 @@
+import { test } from '@playwright/test';
+
+const delay = () => {
+	return new Promise(resolve => setTimeout(resolve, 250));
+};
+
+test.describe('reporter tests 3', () => {
+	test('test', () => { });
+
+	test.skip('skipped test', () => { });
+
+	// eslint-disable-next-line no-unused-vars
+	test('flaky test', async({ page }, testInfo) => {
+		if (testInfo.retry < 2) {
+			await delay();
+
+			throw new Error('flaky test failure');
+		}
+	});
+
+	test('failed test', () => { throw new Error('fail'); });
+});

--- a/test/integration/data/web-test-runner-3.test.js
+++ b/test/integration/data/web-test-runner-3.test.js
@@ -1,0 +1,7 @@
+describe('reporter tests 3', () => {
+	it('test', () => {});
+
+	it.skip('skipped test', () => {});
+
+	it('failed test', () => { throw new Error('fail'); });
+});

--- a/test/integration/report-validation.test.js
+++ b/test/integration/report-validation.test.js
@@ -97,21 +97,12 @@ const partialReportPlaywright = {
 	summary: {
 		status: 'failed',
 		framework: 'playwright',
-		countPassed: 7,
+		countPassed: 5,
 		countFailed: 5,
 		countSkipped: 5,
 		countFlaky: 5
 	},
 	details: [{
-		name: '[setup] > setup',
-		status: 'passed',
-		location: 'test/integration/data/playwright.setup.js',
-		browser: 'chromium',
-		tool: 'Test Reporting',
-		experience: 'Test Framework',
-		type: 'integration',
-		retries: 0
-	}, {
 		name: '[chromium] > reporter tests 1 > skipped test',
 		status: 'skipped',
 		location: 'test/integration/data/playwright-1.test.js',
@@ -291,15 +282,6 @@ const partialReportPlaywright = {
 		experience: 'Playwright 2 Test Framework',
 		type: 'visual diff',
 		retries: 2
-	}, {
-		name: '[teardown] > teardown',
-		status: 'passed',
-		location: 'test/integration/data/playwright.teardown.js',
-		browser: 'chromium',
-		tool: 'Test Reporting',
-		experience: 'Test Framework',
-		type: 'integration',
-		retries: 0
 	}]
 };
 const partialReportWebTestRunner = {


### PR DESCRIPTION
This is mainly so we can ignore global set-up and teardown type of files. I'm a bit on the fence about adding this. I can create a disconnect between the overall status and the actual test statuses (could have all tests show status `passed` but overall show `failed` if the failed test was ignored). I'm hoping to use this very sparingly. It is useful to sometimes ignore files but I'm hoping to use this very sparingly. Resolves #105.

I'm looking for opinions on this one if anyone has any.