### PR TITLE
fix: remove peer dependencies

### DIFF
--- a/.licensechecker.json
+++ b/.licensechecker.json
@@ -1,6 +1,0 @@
-{
-  "manualOverrides": {
-    "crypto-md5@1.0.0": "BSD-2-Clause",
-    "qrcode-terminal@0.10.0": "Apache-2.0"
-  }
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,13 +38,6 @@
       },
       "engines": {
         "node": ">=18"
-      },
-      "peerDependencies": {
-        "@web/test-runner": "^0.18",
-        "mocha": "^10",
-        "playwright": "^1",
-        "testcafe": "^3",
-        "testcafe-reporter-custom": "^1"
       }
     },
     "node_modules/@75lb/deep-merge": {

--- a/package.json
+++ b/package.json
@@ -48,13 +48,6 @@
     "mocha": "^10",
     "playwright-core": "^1"
   },
-  "peerDependencies": {
-    "@web/test-runner": "^0.18",
-    "mocha": "^10",
-    "playwright": "^1",
-    "testcafe": "^3",
-    "testcafe-reporter-custom": "^1"
-  },
   "devDependencies": {
     "@playwright/test": "^1",
     "@web/test-runner": "^0.18",


### PR DESCRIPTION
Now that `npm` installs peers by default I don't want repos that don't have playwright or testcafe or mocha, etc to have it installed. Removing peers so this doesn't happen.