### PR TITLE
fix: null exception when browser fails to launch

### DIFF
--- a/src/reporters/web-test-runner.js
+++ b/src/reporters/web-test-runner.js
@@ -65,6 +65,10 @@ export function reporter(options = {}) {
 	};
 
 	const collectSuite = (session, prefix, suite) => {
+		if (!suite) {
+			return;
+		}
+
 		collectTests(session, prefix, suite.tests);
 
 		for (const childSuite of suite.suites) {


### PR DESCRIPTION
I can't get the browser to fail to start again but this should take care of the issue. It will result in an incomplete report but it will properly represent what ran. Resolves #127.