### PR TITLE
Add custom annotation helpers to inject browser type into report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+blob-report/
 coverage/
 node_modules/
+playwright-report/
 test-results/
 /d2l-test-report*.json
 !/d2l-test-reporting.config.json

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "repository": "https://github.com/Brightspace/test-reporting-node.git",
   "type": "module",
   "exports": {
+    "./helpers/runners/playwright.js": "./src/helpers/runners/playwright.js",
     "./helpers/github.js": "./src/helpers/github.cjs",
     "./helpers/report.js": "./src/helpers/report.cjs",
     "./helpers/report-configuration.js": "./src/helpers/report-configuration.cjs",

--- a/src/helpers/runners/playwright.js
+++ b/src/helpers/runners/playwright.js
@@ -1,0 +1,41 @@
+import base from '@playwright/test';
+
+export const test = base.extend({
+	_annotateBrowser: [
+		async({ browser }, use, testInfo) => {
+			const browserName = browser.browserType().name();
+
+			testInfo.annotations.push({ type: 'browser', description: browserName });
+
+			await use();
+		}, {
+			scope: 'test',
+			auto: true
+		}]
+});
+
+export const setup = base.extend({
+	_annotateSetup: [
+		// eslint-disable-next-line no-empty-pattern
+		async({}, use, testInfo) => {
+			testInfo.annotations.push({ type: 'setup' });
+
+			await use();
+		}, {
+			scope: 'test',
+			auto: true
+		}]
+});
+
+export const teardown = base.extend({
+	_annotateTeardown: [
+		// eslint-disable-next-line no-empty-pattern
+		async({}, use, testInfo) => {
+			testInfo.annotations.push({ type: 'teardown' });
+
+			await use();
+		}, {
+			scope: 'test',
+			auto: true
+		}]
+});

--- a/test/integration/data/config/playwright.js
+++ b/test/integration/data/config/playwright.js
@@ -1,24 +1,21 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const playwrightReporterOptions = {
-	reportPath: './d2l-test-report-playwright.json',
-	verbose: true
-};
-
-const deviceTypeChrome = devices['Desktop Chrome'];
-const deviceTypeFirefox = devices['Desktop Firefox'];
-const deviceTypeSafari = devices['Desktop Safari'];
-
 export default defineConfig({
 	reporter: [
-		['../../../../src/reporters/playwright.js', playwrightReporterOptions],
-		['list']
+		['list'],
+		[
+			'../../../../src/reporters/playwright.js',
+			{
+				reportPath: './d2l-test-report-playwright.json',
+				verbose: true
+			}
+		]
 	],
 	retries: 3,
 	fullyParallel: true,
 	testDir: '../',
 	testMatch: 'playwright-*.test.js',
-	use: deviceTypeChrome,
+	use: devices['Desktop Chrome'],
 	globalSetup: '../playwright.global.setup.js',
 	globalTeardown: '../playwright.global.teardown.js',
 	projects: [{
@@ -34,17 +31,11 @@ export default defineConfig({
 	}, {
 		name: 'firefox',
 		testMatch: 'playwright-2.test.js',
-		use: deviceTypeFirefox,
-		dependencies: ['setup'],
-		metadata: {
-			browserType: deviceTypeFirefox.defaultBrowserType
-		}
+		use: devices['Desktop Firefox'],
+		dependencies: ['setup']
 	}, {
 		name: 'webkit',
-		use: deviceTypeSafari,
-		dependencies: ['setup'],
-		metadata: {
-			browserType: deviceTypeSafari.defaultBrowserType
-		}
+		use: devices['Desktop Safari'],
+		dependencies: ['setup']
 	}]
 });

--- a/test/integration/data/playwright-1.test.js
+++ b/test/integration/data/playwright-1.test.js
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from '../../../src/helpers/runners/playwright.js';
 
 const delay = (ms = 100) => {
 	return new Promise(resolve => setTimeout(resolve, ms));

--- a/test/integration/data/playwright-2.test.js
+++ b/test/integration/data/playwright-2.test.js
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from '../../../src/helpers/runners/playwright.js';
 
 const delay = (ms = 100) => {
 	return new Promise(resolve => setTimeout(resolve, ms));

--- a/test/integration/data/playwright-3.test.js
+++ b/test/integration/data/playwright-3.test.js
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from '../../../src/helpers/runners/playwright.js';
 
 const delay = (ms = 100) => {
 	return new Promise(resolve => setTimeout(resolve, ms));

--- a/test/integration/data/playwright.setup.js
+++ b/test/integration/data/playwright.setup.js
@@ -1,4 +1,4 @@
-import { test as setup } from '@playwright/test';
+import { setup } from '../../../src/helpers/runners/playwright.js';
 
 setup('setup', async() => {
 

--- a/test/integration/data/playwright.teardown.js
+++ b/test/integration/data/playwright.teardown.js
@@ -1,4 +1,4 @@
-import { test as teardown } from '@playwright/test';
+import { teardown } from '../../../src/helpers/runners/playwright.js';
 
 teardown('teardown', async() => {
 


### PR DESCRIPTION
This adds custom test fixtures as well as a custom export for setup/teardown that add annotations to help the reporter fill in missing information. These would need to be adopted by anyone using playwright and would allow us to use merge reports. If not using merge reports they would still be recommended for use but aren't strictly needed.