### PR TITLE
fix: don't return an object in a constructor

### DIFF
--- a/src/helpers/report-configuration.cjs
+++ b/src/helpers/report-configuration.cjs
@@ -28,7 +28,9 @@ class ReportConfiguration {
 			try {
 				contents = readFileSync(path, 'utf8');
 			} catch {
-				return {};
+				this._reportConfiguration = {};
+
+				return;
 			}
 
 			try {


### PR DESCRIPTION
This took me 4 hours to figure out. I hate JavaScript sometimes.  Need to add a test that covers this. Will do that in another PR.