### PR TITLE
Add before/after all/each to test data

### DIFF
--- a/test/integration/data/mocha-1.test.js
+++ b/test/integration/data/mocha-1.test.js
@@ -1,9 +1,13 @@
-const delay = () => {
-	return new Promise(resolve => setTimeout(resolve, 100));
+const delay = (ms = 100) => {
+	return new Promise(resolve => setTimeout(resolve, ms));
 };
 
 describe('reporter tests 1', () => {
 	let count = 0;
+
+	before(async() => { await delay(1000); });
+
+	beforeEach(async() => { await delay(1000); });
 
 	it('test', () => {});
 
@@ -20,4 +24,8 @@ describe('reporter tests 1', () => {
 	});
 
 	it('failed test', () => { throw new Error('fail'); });
+
+	afterEach(async() => { await delay(1000); });
+
+	after(async() => { await delay(1000); });
 });

--- a/test/integration/data/mocha-2.test.js
+++ b/test/integration/data/mocha-2.test.js
@@ -1,9 +1,13 @@
-const delay = () => {
-	return new Promise(resolve => setTimeout(resolve, 100));
+const delay = (ms = 100) => {
+	return new Promise(resolve => setTimeout(resolve, ms));
 };
 
 describe('reporter tests 2', () => {
 	let count = 0;
+
+	before(async() => { await delay(1000); });
+
+	beforeEach(async() => { await delay(1000); });
 
 	it('test', () => {});
 
@@ -20,4 +24,8 @@ describe('reporter tests 2', () => {
 	});
 
 	it('failed test', () => { throw new Error('fail'); });
+
+	afterEach(async() => { await delay(1000); });
+
+	after(async() => { await delay(1000); });
 });

--- a/test/integration/data/mocha-3.test.js
+++ b/test/integration/data/mocha-3.test.js
@@ -1,9 +1,13 @@
-const delay = () => {
-	return new Promise(resolve => setTimeout(resolve, 100));
+const delay = (ms = 100) => {
+	return new Promise(resolve => setTimeout(resolve, ms));
 };
 
 describe('reporter tests 3', () => {
 	let count = 0;
+
+	before(async() => { await delay(1000); });
+
+	beforeEach(async() => { await delay(1000); });
 
 	it('test', () => {});
 
@@ -20,4 +24,8 @@ describe('reporter tests 3', () => {
 	});
 
 	it('failed test', () => { throw new Error('fail'); });
+
+	afterEach(async() => { await delay(1000); });
+
+	after(async() => { await delay(1000); });
 });

--- a/test/integration/data/playwright-1.test.js
+++ b/test/integration/data/playwright-1.test.js
@@ -1,10 +1,14 @@
 import { test } from '@playwright/test';
 
-const delay = () => {
-	return new Promise(resolve => setTimeout(resolve, 100));
+const delay = (ms = 100) => {
+	return new Promise(resolve => setTimeout(resolve, ms));
 };
 
 test.describe('reporter tests 1', () => {
+	test.beforeAll(async() => { await delay(1000); });
+
+	test.beforeEach(async() => { await delay(1000); });
+
 	test('test', () => {});
 
 	test.skip('skipped test', () => {});
@@ -19,4 +23,8 @@ test.describe('reporter tests 1', () => {
 	});
 
 	test('failed test', () => { throw new Error('fail'); });
+
+	test.afterEach(async() => { await delay(1000); });
+
+	test.afterAll(async() => { await delay(1000); });
 });

--- a/test/integration/data/playwright-2.test.js
+++ b/test/integration/data/playwright-2.test.js
@@ -1,10 +1,14 @@
 import { test } from '@playwright/test';
 
-const delay = () => {
-	return new Promise(resolve => setTimeout(resolve, 100));
+const delay = (ms = 100) => {
+	return new Promise(resolve => setTimeout(resolve, ms));
 };
 
 test.describe('reporter tests 2', () => {
+	test.beforeAll(async() => { await delay(1000); });
+
+	test.beforeEach(async() => { await delay(1000); });
+
 	test('test', () => {});
 
 	test.skip('skipped test', () => {});
@@ -19,4 +23,8 @@ test.describe('reporter tests 2', () => {
 	});
 
 	test('failed test', () => { throw new Error('fail'); });
+
+	test.afterEach(async() => { await delay(1000); });
+
+	test.afterAll(async() => { await delay(1000); });
 });

--- a/test/integration/data/playwright-3.test.js
+++ b/test/integration/data/playwright-3.test.js
@@ -1,10 +1,14 @@
 import { test } from '@playwright/test';
 
-const delay = () => {
-	return new Promise(resolve => setTimeout(resolve, 100));
+const delay = (ms = 100) => {
+	return new Promise(resolve => setTimeout(resolve, ms));
 };
 
 test.describe('reporter tests 3', () => {
+	test.beforeAll(async() => { await delay(1000); });
+
+	test.beforeEach(async() => { await delay(1000); });
+
 	test('test', () => {});
 
 	test.skip('skipped test', () => {});
@@ -19,4 +23,8 @@ test.describe('reporter tests 3', () => {
 	});
 
 	test('failed test', () => { throw new Error('fail'); });
+
+	test.afterEach(async() => { await delay(1000); });
+
+	test.afterAll(async() => { await delay(1000); });
 });

--- a/test/integration/data/web-test-runner-1.test.js
+++ b/test/integration/data/web-test-runner-1.test.js
@@ -1,7 +1,19 @@
+const delay = (ms = 100) => {
+	return new Promise(resolve => setTimeout(resolve, ms));
+};
+
 describe('reporter tests 1', () => {
+	before(async() => { await delay(1000); });
+
+	beforeEach(async() => { await delay(1000); });
+
 	it('test', () => {});
 
 	it.skip('skipped test', () => {});
 
 	it('failed test', () => { throw new Error('fail'); });
+
+	afterEach(async() => { await delay(1000); });
+
+	after(async() => { await delay(1000); });
 });

--- a/test/integration/data/web-test-runner-2.test.js
+++ b/test/integration/data/web-test-runner-2.test.js
@@ -1,7 +1,19 @@
+const delay = (ms = 100) => {
+	return new Promise(resolve => setTimeout(resolve, ms));
+};
+
 describe('reporter tests 2', () => {
+	before(async() => { await delay(1000); });
+
+	beforeEach(async() => { await delay(1000); });
+
 	it('test', () => {});
 
 	it.skip('skipped test', () => {});
 
 	it('failed test', () => { throw new Error('fail'); });
+
+	afterEach(async() => { await delay(1000); });
+
+	after(async() => { await delay(1000); });
 });

--- a/test/integration/data/web-test-runner-3.test.js
+++ b/test/integration/data/web-test-runner-3.test.js
@@ -1,7 +1,19 @@
+const delay = (ms = 100) => {
+	return new Promise(resolve => setTimeout(resolve, ms));
+};
+
 describe('reporter tests 3', () => {
+	before(async() => { await delay(1000); });
+
+	beforeEach(async() => { await delay(1000); });
+
 	it('test', () => {});
 
 	it.skip('skipped test', () => {});
 
 	it('failed test', () => { throw new Error('fail'); });
+
+	afterEach(async() => { await delay(1000); });
+
+	after(async() => { await delay(1000); });
 });


### PR DESCRIPTION
Note there are different behaviours depending on framework. Right now this is how it lands.

* `mocha`
  * before/after all/each are all not included in reported times
    * Will look into reporting it separately or adding it to test times depending on what we decide
* `playwright`
  * before/after all are not included in reported times, before/after each are included in reported times
    * Probably fine since the before/after each make sense to be part of the test times
    * Will look into reporting it separately
* `@web/test-runner`
  * before/after all/each are all included in reported times due to how it reports it's timings
    * No nice way around this I've found so far, reported time is of all tests run for that worker
* `testcafe`
  * Don't really care since we're killing it, didn't look into it and don't plan to

In all cases `totalDuration` includes everything all test times, before/after hooks and so on. Once we have an idea what we want to do in terms of timings I can look into adding that to the report validation since the times will always be large than a certain amount now.