### PR TITLE
Always add reviewers for dependabot PR's

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       time: '08:00'
       timezone: America/Toronto
     versioning-strategy: increase
+    reviewers:
+      - Brightspace/quality-enablement-reviewers
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-patch']


### PR DESCRIPTION
These could end up not having us on them due to ignoring the `package-lock.json` file. Doing this makes sure we are on all things dependabot opens.