### PR TITLE
Rework how we do report handling

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,10 +1,10 @@
 {
   "all": true,
   "check-coverage": true,
-  "statements": 85,
+  "statements": 80,
   "branches": 75,
-  "functions": 85,
-  "lines": 85,
+  "functions": 80,
+  "lines": 80,
   "include": [
     "src/**/*.{js,cjs}"
   ],

--- a/src/helpers/github.cjs
+++ b/src/helpers/github.cjs
@@ -1,5 +1,3 @@
-const { formatErrorAjv, validateReportV1ContextLooseAjv, validateReportV1ContextStrictAjv } = require('./schema.cjs');
-
 const hasContext = () => {
 	const { env: { GITHUB_ACTIONS } } = process;
 
@@ -26,26 +24,18 @@ const getContext = () => {
 	const branchRef = GITHUB_HEAD_REF || GITHUB_REF;
 
 	return {
-		githubOrganization: owner,
-		githubRepository: repo,
-		githubWorkflow: workflowPath.replace(workflowRegex, ''),
-		githubRunId: parseInt(GITHUB_RUN_ID, 10),
-		githubRunAttempt: parseInt(GITHUB_RUN_ATTEMPT, 10),
-		gitBranch: branchRef.replace(/^refs\/heads\//i, ''),
-		gitSha: GITHUB_SHA
+		github: {
+			organization: owner,
+			repository: repo,
+			workflow: workflowPath.replace(workflowRegex, ''),
+			runId: parseInt(GITHUB_RUN_ID, 10),
+			runAttempt: parseInt(GITHUB_RUN_ATTEMPT, 10)
+		},
+		git: {
+			branch: branchRef.replace(/^refs\/heads\//i, ''),
+			sha: GITHUB_SHA
+		}
 	};
 };
 
-const validateContext = (context, strict = false) => {
-	const validateContextAjv = strict ?
-		validateReportV1ContextStrictAjv :
-		validateReportV1ContextLooseAjv;
-
-	if (!validateContextAjv(context)) {
-		const { errors } = validateContextAjv;
-
-		throw new Error(formatErrorAjv('github context', errors));
-	}
-};
-
-module.exports = { getContext, hasContext, validateContext };
+module.exports = { getContext, hasContext };

--- a/src/helpers/object.cjs
+++ b/src/helpers/object.cjs
@@ -1,0 +1,29 @@
+const flatten = (obj) => {
+	const result = {};
+
+	for (const i in obj) {
+		if (!Object.prototype.hasOwnProperty.call(obj, i)) {
+			continue;
+		}
+
+		if ((typeof obj[i]) === 'object' && !Array.isArray(obj[i])) {
+			const flatObject = flatten(obj[i]);
+
+			for (const x in flatObject) {
+				if (!Object.prototype.hasOwnProperty.call(flatObject, x)) {
+					continue;
+				}
+
+				const key = `${i}${x.charAt(0).toUpperCase()}${x.substring(1)}`;
+
+				result[key] = flatObject[x];
+			}
+		} else {
+			result[i] = obj[i];
+		}
+	}
+
+	return result;
+};
+
+module.exports = { flatten };

--- a/src/helpers/report-builder.cjs
+++ b/src/helpers/report-builder.cjs
@@ -1,9 +1,10 @@
 const { getContext, hasContext } = require('./github.cjs');
 const { getOperatingSystemType, makeRelativeFilePath } = require('./system.cjs');
-const { writeFileSync } = require('node:fs');
-const { resolve } = require('node:path');
+const { flatten } = require('./object.cjs');
 const { randomUUID } = require('node:crypto');
+const { resolve } = require('node:path');
 const { ReportConfiguration } = require('./report-configuration.cjs');
+const { writeFileSync } = require('node:fs');
 
 const defaultReportPath = './d2l-test-report.json';
 const reportMemberPriority = [
@@ -66,11 +67,11 @@ class ReportSummaryBuilder {
 
 	addContext() {
 		if (hasContext()) {
-			const githubContext = getContext();
+			const context = getContext();
 
 			this._reportSummary = {
 				...this._reportSummary,
-				...githubContext
+				...flatten(context)
 			};
 		} else {
 			this._logger.warning('D2L test report will not contain GitHub context details');

--- a/src/helpers/report-configuration.cjs
+++ b/src/helpers/report-configuration.cjs
@@ -19,7 +19,7 @@ class ReportConfiguration {
 
 				reportConfiguration = JSON.parse(contents);
 			} catch {
-				throw new Error(`Unable to read/parse configuration at path ${path}`);
+				throw new Error(`Unable to read/parse report configuration at path ${path}`);
 			}
 
 			reportConfigurationPath = makeRelativeFilePath(path);
@@ -39,7 +39,7 @@ class ReportConfiguration {
 			try {
 				reportConfiguration = JSON.parse(contents);
 			} catch {
-				throw new Error(`Unable to read/parse configuration at path ${path}`);
+				throw new Error(`Unable to read/parse report configuration at path ${path}`);
 			}
 
 			reportConfigurationPath = makeRelativeFilePath(path);
@@ -115,6 +115,10 @@ class ReportConfiguration {
 		}
 
 		return false;
+	}
+
+	toJSON() {
+		return this._reportConfiguration;
 	}
 }
 

--- a/src/helpers/report.cjs
+++ b/src/helpers/report.cjs
@@ -1,11 +1,175 @@
-const { formatErrorAjv, validateReportV1Ajv } = require('./schema.cjs');
+const { formatErrorAjv, validateReportV1Ajv, validateReportV1ContextAjv, latestReportVersion } = require('./schema.cjs');
+const { flatten } = require('./object.cjs');
+const fs = require('node:fs');
+const { makeRelativeFilePath } = require('./system.cjs');
+const { resolve } = require('node:path');
 
-const validateReport = (report) => {
+const validateReport = (report, dataVar = 'report') => {
 	if (!validateReportV1Ajv(report)) {
 		const { errors } = validateReportV1Ajv;
 
-		throw new Error(formatErrorAjv('report', errors));
+		throw new Error(formatErrorAjv(dataVar, errors));
 	}
 };
 
-module.exports = { validateReport };
+const getReportVersion = (report) => {
+	const { reportVersion } = report;
+
+	switch (reportVersion) {
+		case null:
+		case undefined:
+			throw new Error('Unable to determine report version');
+		default:
+			return reportVersion;
+	}
+};
+
+const injectReportV1Context = (report, context, override) => {
+	const { summary } = report;
+
+	if (!summary) {
+		throw new Error('Report is missing needed property \'summary\'');
+	}
+
+	if (override) {
+		report.summary = {
+			...summary,
+			...flatten(context)
+		};
+	} else if (!validateReportV1ContextAjv(summary)) {
+		report.summary = {
+			...summary,
+			...flatten(context)
+		};
+	}
+
+	return report;
+};
+
+const injectReportContext = (report, context, override) => {
+	const reportVersion = getReportVersion(report);
+
+	switch (reportVersion) {
+		case 1:
+			return injectReportV1Context(report, context, override);
+		default:
+			throw new Error(`Unknown report version '${reportVersion}'`);
+	}
+};
+
+const injectReportV1LmsInfo = (report, lmsInfo) => {
+	const { summary } = report;
+
+	if (!summary) {
+		throw new Error('Report is missing needed property \'summary\'');
+	}
+
+	const { buildNumber, instanceUrl } = lmsInfo;
+
+	if (buildNumber) {
+		if (!summary.lmsBuildNumber) {
+			summary.lmsBuildNumber = buildNumber;
+		} else {
+			throw new Error('LMS build number already present');
+		}
+	}
+
+	if (instanceUrl) {
+		if (!summary.lmsInstanceUrl) {
+			summary.lmsInstanceUrl = instanceUrl;
+		} else {
+			throw new Error('LMS instance URL already present');
+		}
+	}
+
+	report.summary = summary;
+
+	return report;
+};
+
+const injectReportLmsInfo = (report, lmsInfo) => {
+	const reportVersion = getReportVersion(report);
+
+	switch (reportVersion) {
+		case 1:
+			return injectReportV1LmsInfo(report, lmsInfo);
+		default:
+			throw new Error(`Unknown report version '${reportVersion}'`);
+	}
+};
+
+const upgradeReport = (report) => {
+	const reportVersion = getReportVersion(report);
+
+	switch (reportVersion) {
+		case 1:
+			return report;
+		default:
+			throw new Error(`Unknown report version: ${reportVersion}`);
+	}
+};
+
+class Report {
+	constructor(path, { context, lmsInfo, overrideContext = false } = {}) {
+		let report;
+
+		try {
+			path = resolve(path);
+
+			const contents = fs.readFileSync(path, 'utf8');
+
+			report = JSON.parse(contents);
+		} catch {
+			throw new Error(`Unable to read/parse report at path ${path}`);
+		}
+
+		if (context) {
+			report = injectReportContext(report, context, overrideContext);
+		}
+
+		if (lmsInfo) {
+			report = injectReportLmsInfo(report, context, overrideContext);
+		}
+
+		const reportVersionOriginal = getReportVersion(report);
+
+		validateReport(report, `report (v${reportVersionOriginal})`);
+
+		this._reportVersionOriginal = reportVersionOriginal;
+
+		if (reportVersionOriginal < latestReportVersion) {
+			upgradeReport(report);
+
+			const reportVersionUpgraded = getReportVersion(report);
+
+			validateReport(report, `report (v${reportVersionUpgraded})`);
+		} else if (reportVersionOriginal > latestReportVersion) {
+			throw new Error(`Unsupported report version specified: ${reportVersionOriginal}`);
+		}
+
+		this._report = report;
+		this._reportPath = makeRelativeFilePath(path);
+	}
+
+	getPath() {
+		return this._reportPath;
+	}
+
+	getId() {
+		return this._report.reportId;
+	}
+
+	getVersionOriginal() {
+		return this._reportVersionOriginal;
+	}
+
+	getVersion() {
+		return this._report.reportVersion;
+	}
+
+	toJSON() {
+		return this._report;
+	}
+}
+
+module.exports = { Report };

--- a/src/helpers/report.cjs
+++ b/src/helpers/report.cjs
@@ -128,7 +128,7 @@ class Report {
 		}
 
 		if (lmsInfo) {
-			report = injectReportLmsInfo(report, context, overrideContext);
+			report = injectReportLmsInfo(report, lmsInfo);
 		}
 
 		const reportVersionOriginal = getReportVersion(report);

--- a/src/helpers/schema.cjs
+++ b/src/helpers/schema.cjs
@@ -15,24 +15,16 @@ addFormats(ajv, ['date-time', 'uri', 'uuid']);
 
 ajv.addSchema({
 	$schema: 'https://json-schema.org/draft/2019-09/schema',
-	$id: '/test-reporting/schemas/report/v1/context/strict.json',
-	$ref: '/test-reporting/schemas/report/v1/context.json',
-	type: 'object',
-	unevaluatedProperties: false
-});
-
-ajv.addSchema({
-	$schema: 'https://json-schema.org/draft/2019-09/schema',
 	$id: '/test-reporting/schemas/report/v1/context/loose.json',
 	$ref: '/test-reporting/schemas/report/v1/context.json',
 	type: 'object',
 	unevaluatedProperties: true
 });
 
-const validateReportV1ContextLooseAjv = ajv.getSchema('/test-reporting/schemas/report/v1/context/loose.json');
-const validateReportV1ContextStrictAjv = ajv.getSchema('/test-reporting/schemas/report/v1/context/strict.json');
+const validateReportV1ContextAjv = ajv.getSchema('/test-reporting/schemas/report/v1/context/loose.json');
 const validateReportConfigurationV1Ajv = ajv.getSchema('/test-reporting/schemas/report-configuration/v1.json');
 const validateReportV1Ajv = ajv.getSchema('/test-reporting/schemas/report/v1.json');
+const latestReportVersion = 1;
 
 const formatErrorAjv = (dataVar, errors) => {
 	const { instancePath, message: ajvMessage, parentSchema: { type }, data } = errors[0];
@@ -55,7 +47,7 @@ const formatErrorAjv = (dataVar, errors) => {
 module.exports = {
 	formatErrorAjv,
 	validateReportConfigurationV1Ajv,
-	validateReportV1ContextLooseAjv,
-	validateReportV1ContextStrictAjv,
-	validateReportV1Ajv
+	validateReportV1Ajv,
+	validateReportV1ContextAjv,
+	latestReportVersion
 };

--- a/test/unit/github.test.js
+++ b/test/unit/github.test.js
@@ -1,15 +1,19 @@
-import { getContext, hasContext, validateContext } from '../../src/helpers/github.cjs';
+import { getContext, hasContext } from '../../src/helpers/github.cjs';
 import { createSandbox } from 'sinon';
 import { expect } from 'chai';
 
 const validContext = {
-	githubOrganization: 'TestOrganization',
-	githubRepository: 'test-repository',
-	githubWorkflow: 'test-workflow.yml',
-	githubRunId: 12345,
-	githubRunAttempt: 1,
-	gitBranch: 'test/branch',
-	gitSha: '0000000000000000000000000000000000000000'
+	github: {
+		organization: 'TestOrganization',
+		repository: 'test-repository',
+		workflow: 'test-workflow.yml',
+		runId: 12345,
+		runAttempt: 1
+	},
+	git: {
+		branch: 'test/branch',
+		sha: '0000000000000000000000000000000000000000'
+	}
 };
 
 describe('github', () => {
@@ -72,33 +76,6 @@ describe('github', () => {
 			sandbox.stub(process, 'env').value({});
 
 			expect(getContext).to.throw('GitHub context unavailable');
-		});
-	});
-
-	describe('validate context', () => {
-		const validContextExtraProperties = {
-			...validContext,
-			test: 'test'
-		};
-
-		it('strict', () => {
-			const wrapper = () => validateContext(validContext, true);
-
-			expect(wrapper).to.not.throw();
-		});
-
-		it('loose', () => {
-			const wrapper = () => validateContext(validContextExtraProperties);
-
-			expect(wrapper).to.not.throw();
-		});
-
-		describe('fails', () => {
-			it('strict with extra properties', () => {
-				const wrapper = () => validateContext(validContextExtraProperties, true);
-
-				expect(wrapper).to.throw('github context does not conform to schema');
-			});
 		});
 	});
 });

--- a/test/unit/report.test.js
+++ b/test/unit/report.test.js
@@ -1,7 +1,26 @@
+import { createSandbox } from 'sinon';
 import { expect } from 'chai';
-import { validateReport } from '../../src/helpers/report.cjs';
+import { flatten } from '../../src/helpers/object.cjs';
+import fs from 'node:fs';
+import { Report } from '../../src/helpers/report.cjs';
+import { resolve } from 'node:path';
 
-const validReport = {
+const reportPath = resolve('./test-report.json');
+const reportOverrideContext = {
+	github: {
+		organization: 'TestOrganizationOther',
+		repository: 'test-repository-other',
+		workflow: 'test-workflow-other.yml',
+		runId: 67890,
+		runAttempt: 2
+	},
+	git: {
+		branch: 'test/branch/other',
+		sha: '0000000000000000000000000000000000000000'
+	}
+};
+const reportStarted = (new Date()).toISOString();
+const reportFull = {
 	reportId: '00000000-0000-0000-0000-000000000000',
 	reportVersion: 1,
 	summary: {
@@ -14,7 +33,7 @@ const validReport = {
 		gitSha: '0000000000000000000000000000000000000000',
 		operatingSystem: 'linux',
 		framework: 'mocha',
-		started: (new Date()).toISOString(),
+		started: reportStarted,
 		totalDuration: 23857,
 		status: 'passed',
 		countPassed: 2,
@@ -25,7 +44,7 @@ const validReport = {
 	details: [{
 		name: 'test suite > flaky test',
 		location: 'test/test-suite.js',
-		started: (new Date()).toISOString(),
+		started: reportStarted,
 		duration: 237,
 		totalDuration: 549,
 		status: 'passed',
@@ -33,7 +52,7 @@ const validReport = {
 	}, {
 		name: 'test suite > passing test',
 		location: 'test/test-suite.js',
-		started: (new Date()).toISOString(),
+		started: reportStarted,
 		duration: 237,
 		totalDuration: 237,
 		status: 'passed',
@@ -41,38 +60,156 @@ const validReport = {
 	}, {
 		name: 'test suite > skipped test',
 		location: 'test/test-suite.js',
-		started: (new Date()).toISOString(),
+		started: reportStarted,
 		duration: 0,
 		totalDuration: 0,
 		status: 'skipped',
 		retries: 0
 	}]
 };
+const reportFullOverridden = {
+	...reportFull,
+	summary: {
+		...reportFull.summary,
+		...flatten(reportOverrideContext)
+	}
+};
+const reportNoContext = {
+	...reportFull,
+	summary: {
+		operatingSystem: 'linux',
+		framework: 'mocha',
+		started: reportStarted,
+		totalDuration: 23857,
+		status: 'passed',
+		countPassed: 2,
+		countFailed: 0,
+		countSkipped: 1,
+		countFlaky: 1
+	}
+};
+const reportPartialContext = {
+	...reportFull,
+	summary: {
+		githubOrganization: 'TestOrganization',
+		githubWorkflow: 'test-workflow.yml',
+		gitBranch: 'test/branch',
+		gitSha: '0000000000000000000000000000000000000000',
+		operatingSystem: 'linux',
+		framework: 'mocha',
+		started: reportStarted,
+		totalDuration: 23857,
+		status: 'passed',
+		countPassed: 2,
+		countFailed: 0,
+		countSkipped: 1,
+		countFlaky: 1
+	}
+};
 
 describe('report', () => {
-	describe('validate', () => {
-		it('succeeds', () => {
-			const wrapper = () => validateReport(validReport);
+	let sandbox;
+
+	before(() => sandbox = createSandbox());
+
+	afterEach(() => sandbox.restore());
+
+	describe('construction', () => {
+		it('don\'t override context', () => {
+			sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(reportFull));
+
+			let report;
+
+			const wrapper = () => report = (new Report(reportPath));
 
 			expect(wrapper).to.not.throw();
+			expect(report.toJSON()).to.deep.equal(reportFull);
 		});
 
-		describe('fails', () => {
-			it('invalid', () => {
-				const wrapper = () => validateReport({});
+		describe('full report', () => {
+			it('override context', () => {
+				sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(reportFull));
 
-				expect(wrapper).to.throw('report does not conform to schema');
+				const reportOptions = {
+					context: reportOverrideContext,
+					overrideContext: true
+				};
+				let report;
+
+				const wrapper = () => report = new Report(reportPath, reportOptions);
+
+				expect(wrapper).to.not.throw();
+				expect(report.toJSON()).to.deep.equal(reportFullOverridden);
 			});
 
-			it('extra properties', () => {
-				const extraProperties = {
-					...validReport,
-					test: 'test'
+			it('inject context if needed', () => {
+				sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(reportFull));
+
+				const reportOptions = { context: reportOverrideContext };
+				let report;
+
+				const wrapper = () => report = (new Report(reportPath, reportOptions));
+
+				expect(wrapper).to.not.throw();
+				expect(report.toJSON()).to.deep.equal(reportFull);
+			});
+		});
+
+		describe('no context', () => {
+			it('override context', () => {
+				sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(reportNoContext));
+
+				const reportOptions = {
+					context: reportOverrideContext,
+					overrideContext: true
 				};
+				let report;
 
-				const wrapper = () => validateReport(extraProperties);
+				const wrapper = () => report = (new Report(reportPath, reportOptions));
 
-				expect(wrapper).to.throw('report does not conform to schema');
+				expect(wrapper).to.not.throw();
+				expect(report.toJSON()).to.deep.equal(reportFullOverridden);
+			});
+
+			it('inject context if needed', () => {
+				sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(reportNoContext));
+
+				const reportOptions = { context: reportOverrideContext };
+				let report;
+
+				const wrapper = () => report = (new Report(reportPath, reportOptions));
+
+				expect(wrapper).to.not.throw();
+				expect(report.toJSON()).to.deep.equal(reportFullOverridden);
+			});
+		});
+
+		describe('partial context', () => {
+			it('override context', () => {
+				sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(reportPartialContext));
+
+				const reportOptions = {
+					context: reportOverrideContext,
+					overrideContext: true
+				};
+				let report;
+
+				const wrapper = () => report = (new Report(reportPath, reportOptions));
+
+				expect(wrapper).to.not.throw();
+				expect(report.toJSON()).to.deep.equal(reportFullOverridden);
+			});
+
+			it('inject context if needed', () => {
+				sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(reportPartialContext));
+
+				const reportOptions = { context: reportOverrideContext };
+				let report;
+
+				const wrapper = () => report = (new Report(reportPath, reportOptions));
+
+				expect(wrapper).to.not.throw();
+				expect(report.toJSON()).to.deep.equal(reportFullOverridden);
 			});
 		});
 	});


### PR DESCRIPTION
This reworks how we handle reports entirely and adds a top level `Report` object that we can load, validate and upgrade reports with. By default it will always validate the incoming report, upgrade it to the latest report version then validate it again. Right now we only have 1 version but this is going to change soon. Having this kind of pipelines upgrades will be handy for keeping backways compatibility is needed. It also allows us to deprecate older version of reports with a nice interface/error messaging. The `ReportBuilder` should always be built to output the latest report format.