### PR TITLE
feat: add report v2 schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "ajv": "^8",
         "ajv-formats": "^3",
         "chalk": "^5",
+        "lodash": "^4",
         "minimatch": "^9",
         "mocha": "^10",
         "playwright-core": "^1.43.1"
@@ -8461,8 +8462,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.assignwith": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ajv": "^8",
     "ajv-formats": "^3",
     "chalk": "^5",
+    "lodash": "^4",
     "minimatch": "^9",
     "mocha": "^10",
     "playwright-core": "^1.43.1"

--- a/schemas/report/v2.json
+++ b/schemas/report/v2.json
@@ -1,0 +1,286 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "/test-reporting/schemas/report/v2.json",
+  "type": "object",
+  "unevaluatedProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "version": {
+      "type": "integer",
+      "const": 2
+    },
+    "summary": {
+      "$ref": "#/$defs/context",
+      "type": "object",
+      "unevaluatedProperties": false,
+      "properties": {
+        "framework": {
+          "$ref": "#/$defs/nonEmptyUnpaddedString"
+        },
+        "lms": {
+          "type": "object",
+          "properties": {
+            "buildNumber": {
+              "type": "string",
+              "pattern": "([0-9]{2}\\.){2}[0-9]{1,2}\\.[0-9]{5}"
+            },
+            "instanceUrl": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        "operatingSystem": {
+          "type": "string",
+          "enum": [
+            "windows",
+            "linux",
+            "mac"
+          ]
+        },
+        "started": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "duration": {
+          "type": "object",
+          "properties": {
+            "total": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "required": [
+            "total"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "passed",
+            "failed"
+          ]
+        },
+        "count": {
+          "type": "object",
+          "properties": {
+            "passed": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "failed": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "skipped": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "flaky": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "required": [
+            "passed",
+            "failed",
+            "skipped",
+            "flaky"
+          ]
+        }
+      },
+      "required": [
+        "operatingSystem",
+        "framework",
+        "started",
+        "duration",
+        "status",
+        "count"
+      ]
+    },
+    "details": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "unevaluatedProperties": false,
+        "properties": {
+          "name": {
+            "$ref": "#/$defs/nonEmptyUnpaddedString"
+          },
+          "location": {
+            "type": "object",
+            "properties": {
+              "file": {
+                "$ref": "#/$defs/nonEmptyUnpaddedString"
+              },
+              "line": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "column": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "file"
+            ]
+          },
+          "tool": {
+            "$ref": "#/$defs/nonEmptyUnpaddedString"
+          },
+          "experience": {
+            "$ref": "#/$defs/nonEmptyUnpaddedString"
+          },
+          "type": {
+            "$ref": "#/$defs/nonEmptyUnpaddedString"
+          },
+          "started": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeout": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "duration": {
+            "type": "object",
+            "properties": {
+              "final": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "total": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "final",
+              "total"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "passed",
+              "failed",
+              "skipped"
+            ]
+          },
+          "browser": {
+            "type": "string",
+            "enum": [
+              "chromium",
+              "chrome",
+              "firefox",
+              "webkit",
+              "safari",
+              "edge"
+            ]
+          },
+          "retries": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "error": {
+            "$ref": "#/$defs/nonEmptyUnpaddedString"
+          }
+        },
+        "required": [
+          "name",
+          "location",
+          "started",
+          "duration",
+          "status",
+          "retries"
+        ]
+      }
+    }
+  },
+  "required": [
+    "id",
+    "version",
+    "summary",
+    "details"
+  ],
+  "$defs": {
+    "nonEmptyUnpaddedString": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "/test-reporting/schemas/report/v2/non-empty-unpadded-string.json",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!\\s).+(?<!\\s)$"
+    },
+    "context": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "/test-reporting/schemas/report/v2/context.json",
+      "type": "object",
+      "properties": {
+        "github": {
+          "type": "object",
+          "properties": {
+            "organization": {
+              "$ref": "#/$defs/gitHubAllowedCharactersString"
+            },
+            "repository": {
+              "$ref": "#/$defs/gitHubAllowedCharactersString"
+            },
+            "workflow": {
+              "$ref": "/test-reporting/schemas/report/v2/non-empty-unpadded-string.json"
+            },
+            "runId": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "runAttempt": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          "required": [
+            "organization",
+            "repository",
+            "workflow",
+            "runId",
+            "runAttempt"
+          ]
+        },
+        "git": {
+          "type": "object",
+          "properties": {
+            "branch": {
+              "$ref": "/test-reporting/schemas/report/v2/non-empty-unpadded-string.json"
+            },
+            "sha": {
+              "type": "string",
+              "minLength": 40,
+              "maxLength": 40,
+              "pattern": "[A-Fa-f0-9]+"
+            }
+          },
+          "required": [
+            "branch",
+            "sha"
+          ]
+        }
+      },
+      "required": [
+        "github",
+        "git"
+      ],
+      "$defs": {
+        "gitHubAllowedCharactersString": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[A-Za-z0-9_.-]+"
+        }
+      }
+    }
+  }
+}

--- a/src/helpers/schema.cjs
+++ b/src/helpers/schema.cjs
@@ -7,7 +7,8 @@ const ajv = new Ajv({
 	allErrors: false,
 	schemas: [
 		require('../../schemas/report-configuration/v1.json'),
-		require('../../schemas/report/v1.json')
+		require('../../schemas/report/v1.json'),
+		require('../../schemas/report/v2.json')
 	]
 });
 
@@ -21,10 +22,12 @@ ajv.addSchema({
 	unevaluatedProperties: true
 });
 
-const validateReportV1ContextAjv = ajv.getSchema('/test-reporting/schemas/report/v1/context/loose.json');
 const validateReportConfigurationV1Ajv = ajv.getSchema('/test-reporting/schemas/report-configuration/v1.json');
+const validateReportV1ContextAjv = ajv.getSchema('/test-reporting/schemas/report/v1/context/loose.json');
+const validateReportV2ContextAjv = ajv.getSchema('/test-reporting/schemas/report/v2/context/loose.json');
 const validateReportV1Ajv = ajv.getSchema('/test-reporting/schemas/report/v1.json');
-const latestReportVersion = 1;
+const validateReportV2Ajv = ajv.getSchema('/test-reporting/schemas/report/v2.json');
+const latestReportVersion = 2;
 
 const formatErrorAjv = (dataVar, errors) => {
 	const { instancePath, message: ajvMessage, parentSchema: { type }, data } = errors[0];
@@ -47,7 +50,9 @@ const formatErrorAjv = (dataVar, errors) => {
 module.exports = {
 	formatErrorAjv,
 	validateReportConfigurationV1Ajv,
-	validateReportV1Ajv,
 	validateReportV1ContextAjv,
+	validateReportV2ContextAjv,
+	validateReportV1Ajv,
+	validateReportV2Ajv,
 	latestReportVersion
 };

--- a/test/integration/data/validation/test-report-mocha.js
+++ b/test/integration/data/validation/test-report-mocha.js
@@ -74,3 +74,76 @@ export const testReportV1Partial = {
 		retries: 3
 	}]
 };
+export const testReportV2Partial = {
+	version: 2,
+	summary: {
+		status: 'failed',
+		framework: 'mocha',
+		count: { passed: 2, failed: 2, skipped: 2, flaky: 2 }
+	},
+	details: [{
+		name: 'reporter tests 1 > test',
+		status: 'passed',
+		location: { file: 'test/integration/data/mocha-1.test.js' },
+		tool: 'Mocha 1 Test Reporting',
+		experience: 'Test Framework',
+		type: 'ui',
+		retries: 0
+	}, {
+		name: 'reporter tests 1 > skipped test',
+		status: 'skipped',
+		location: { file: 'test/integration/data/mocha-1.test.js' },
+		tool: 'Mocha 1 Test Reporting',
+		experience: 'Test Framework',
+		type: 'ui',
+		retries: 0
+	}, {
+		name: 'reporter tests 1 > flaky test',
+		status: 'passed',
+		location: { file: 'test/integration/data/mocha-1.test.js' },
+		tool: 'Mocha 1 Test Reporting',
+		experience: 'Test Framework',
+		type: 'ui',
+		retries: 2
+	}, {
+		name: 'reporter tests 1 > failed test',
+		status: 'failed',
+		location: { file: 'test/integration/data/mocha-1.test.js' },
+		tool: 'Mocha 1 Test Reporting',
+		experience: 'Test Framework',
+		type: 'ui',
+		retries: 3
+	}, {
+		name: 'reporter tests 2 > test',
+		status: 'passed',
+		location: { file: 'test/integration/data/mocha-2.test.js' },
+		tool: 'Test Reporting',
+		experience: 'Mocha 2 Test Framework',
+		type: 'integration',
+		retries: 0
+	}, {
+		name: 'reporter tests 2 > skipped test',
+		status: 'skipped',
+		location: { file: 'test/integration/data/mocha-2.test.js' },
+		tool: 'Test Reporting',
+		experience: 'Mocha 2 Test Framework',
+		type: 'integration',
+		retries: 0
+	}, {
+		name: 'reporter tests 2 > flaky test',
+		status: 'passed',
+		location: { file: 'test/integration/data/mocha-2.test.js' },
+		tool: 'Test Reporting',
+		experience: 'Mocha 2 Test Framework',
+		type: 'integration',
+		retries: 2
+	}, {
+		name: 'reporter tests 2 > failed test',
+		status: 'failed',
+		location: { file: 'test/integration/data/mocha-2.test.js' },
+		tool: 'Test Reporting',
+		experience: 'Mocha 2 Test Framework',
+		type: 'integration',
+		retries: 3
+	}]
+};

--- a/test/integration/data/validation/test-report-playwright.js
+++ b/test/integration/data/validation/test-report-playwright.js
@@ -190,3 +190,192 @@ export const testReportV1Partial = {
 		retries: 2
 	}]
 };
+export const testReportV2Partial = {
+	version: 2,
+	summary: {
+		status: 'failed',
+		framework: 'playwright',
+		count: { passed: 5, failed: 5, skipped: 5, flaky: 5 }
+	},
+	details: [{
+		name: '[chromium] > reporter tests 1 > skipped test',
+		status: 'skipped',
+		location: { file: 'test/integration/data/playwright-1.test.js' },
+		browser: 'chromium',
+		tool: 'Playwright 1 Test Reporting',
+		experience: 'Playwright 1 Test Framework',
+		type: 'integration',
+		retries: 0
+	}, {
+		name: '[chromium] > reporter tests 2 > skipped test',
+		status: 'skipped',
+		location: { file: 'test/integration/data/playwright-2.test.js' },
+		browser: 'chromium',
+		tool: 'Test Reporting',
+		experience: 'Playwright 2 Test Framework',
+		type: 'visual diff',
+		retries: 0
+	}, {
+		name: '[firefox] > reporter tests 2 > skipped test',
+		status: 'skipped',
+		location: { file: 'test/integration/data/playwright-2.test.js' },
+		browser: 'firefox',
+		tool: 'Test Reporting',
+		experience: 'Playwright 2 Test Framework',
+		type: 'visual diff',
+		retries: 0
+	}, {
+		name: '[chromium] > reporter tests 1 > test',
+		status: 'passed',
+		location: { file: 'test/integration/data/playwright-1.test.js' },
+		browser: 'chromium',
+		tool: 'Playwright 1 Test Reporting',
+		experience: 'Playwright 1 Test Framework',
+		type: 'integration',
+		retries: 0
+	}, {
+		name: '[chromium] > reporter tests 2 > test',
+		status: 'passed',
+		location: { file: 'test/integration/data/playwright-2.test.js' },
+		browser: 'chromium',
+		tool: 'Test Reporting',
+		experience: 'Playwright 2 Test Framework',
+		type: 'visual diff',
+		retries: 0
+	}, {
+		name: '[chromium] > reporter tests 1 > failed test',
+		status: 'failed',
+		location: { file: 'test/integration/data/playwright-1.test.js' },
+		browser: 'chromium',
+		tool: 'Playwright 1 Test Reporting',
+		experience: 'Playwright 1 Test Framework',
+		type: 'integration',
+		retries: 3
+	}, {
+		name: '[firefox] > reporter tests 2 > test',
+		status: 'passed',
+		location: { file: 'test/integration/data/playwright-2.test.js' },
+		browser: 'firefox',
+		tool: 'Test Reporting',
+		experience: 'Playwright 2 Test Framework',
+		type: 'visual diff',
+		retries: 0
+	}, {
+		name: '[webkit] > reporter tests 1 > skipped test',
+		status: 'skipped',
+		location: { file: 'test/integration/data/playwright-1.test.js' },
+		browser: 'webkit',
+		tool: 'Playwright 1 Test Reporting',
+		experience: 'Playwright 1 Test Framework',
+		type: 'integration',
+		retries: 0
+	}, {
+		name: '[chromium] > reporter tests 2 > failed test',
+		status: 'failed',
+		location: { file: 'test/integration/data/playwright-2.test.js' },
+		browser: 'chromium',
+		tool: 'Test Reporting',
+		experience: 'Playwright 2 Test Framework',
+		type: 'visual diff',
+		retries: 3
+	}, {
+		name: '[firefox] > reporter tests 2 > failed test',
+		status: 'failed',
+		location: { file: 'test/integration/data/playwright-2.test.js' },
+		browser: 'firefox',
+		tool: 'Test Reporting',
+		experience: 'Playwright 2 Test Framework',
+		type: 'visual diff',
+		retries: 3
+	}, {
+		name: '[webkit] > reporter tests 1 > test',
+		status: 'passed',
+		location: { file: 'test/integration/data/playwright-1.test.js' },
+		browser: 'webkit',
+		tool: 'Playwright 1 Test Reporting',
+		experience: 'Playwright 1 Test Framework',
+		type: 'integration',
+		retries: 0
+	}, {
+		name: '[webkit] > reporter tests 1 > failed test',
+		status: 'failed',
+		location: { file: 'test/integration/data/playwright-1.test.js' },
+		browser: 'webkit',
+		tool: 'Playwright 1 Test Reporting',
+		experience: 'Playwright 1 Test Framework',
+		type: 'integration',
+		retries: 3
+	}, {
+		name: '[chromium] > reporter tests 1 > flaky test',
+		status: 'passed',
+		location: { file: 'test/integration/data/playwright-1.test.js' },
+		browser: 'chromium',
+		tool: 'Playwright 1 Test Reporting',
+		experience: 'Playwright 1 Test Framework',
+		type: 'integration',
+		retries: 2
+	}, {
+		name: '[chromium] > reporter tests 2 > flaky test',
+		status: 'passed',
+		location: { file: 'test/integration/data/playwright-2.test.js' },
+		browser: 'chromium',
+		tool: 'Test Reporting',
+		experience: 'Playwright 2 Test Framework',
+		type: 'visual diff',
+		retries: 2
+	}, {
+		name: '[webkit] > reporter tests 1 > flaky test',
+		status: 'passed',
+		location: { file: 'test/integration/data/playwright-1.test.js' },
+		browser: 'webkit',
+		tool: 'Playwright 1 Test Reporting',
+		experience: 'Playwright 1 Test Framework',
+		type: 'integration',
+		retries: 2
+	}, {
+		name: '[webkit] > reporter tests 2 > skipped test',
+		status: 'skipped',
+		location: { file: 'test/integration/data/playwright-2.test.js' },
+		browser: 'webkit',
+		tool: 'Test Reporting',
+		experience: 'Playwright 2 Test Framework',
+		type: 'visual diff',
+		retries: 0
+	}, {
+		name: '[firefox] > reporter tests 2 > flaky test',
+		status: 'passed',
+		location: { file: 'test/integration/data/playwright-2.test.js' },
+		browser: 'firefox',
+		tool: 'Test Reporting',
+		experience: 'Playwright 2 Test Framework',
+		type: 'visual diff',
+		retries: 2
+	}, {
+		name: '[webkit] > reporter tests 2 > test',
+		status: 'passed',
+		location: { file: 'test/integration/data/playwright-2.test.js' },
+		browser: 'webkit',
+		tool: 'Test Reporting',
+		experience: 'Playwright 2 Test Framework',
+		type: 'visual diff',
+		retries: 0
+	}, {
+		name: '[webkit] > reporter tests 2 > failed test',
+		status: 'failed',
+		location: { file: 'test/integration/data/playwright-2.test.js' },
+		browser: 'webkit',
+		tool: 'Test Reporting',
+		experience: 'Playwright 2 Test Framework',
+		type: 'visual diff',
+		retries: 3
+	}, {
+		name: '[webkit] > reporter tests 2 > flaky test',
+		status: 'passed',
+		location: { file: 'test/integration/data/playwright-2.test.js' },
+		browser: 'webkit',
+		tool: 'Test Reporting',
+		experience: 'Playwright 2 Test Framework',
+		type: 'visual diff',
+		retries: 2
+	}]
+};

--- a/test/integration/data/validation/test-report-testcafe.js
+++ b/test/integration/data/validation/test-report-testcafe.js
@@ -226,3 +226,228 @@ export const testReportV1Partial = {
 		retries: 3
 	}]
 };
+export const testReportV2Partial = {
+	version: 2,
+	summary: {
+		status: 'failed',
+		framework: 'testcafe',
+		count: { passed: 6, failed: 6, skipped: 6, flaky: 6 }
+	},
+	details: [{
+		name: 'fixture 1 > test',
+		status: 'passed',
+		location: { file: 'test/integration/data/testcafe-1.test.js' },
+		browser: 'firefox',
+		tool: 'TestCafe 1 Test Reporting',
+		experience: 'Test Framework',
+		type: 'ui',
+		retries: 0
+	}, {
+		name: 'fixture 1 > test',
+		status: 'passed',
+		location: { file: 'test/integration/data/testcafe-1.test.js' },
+		browser: 'chrome',
+		tool: 'TestCafe 1 Test Reporting',
+		experience: 'Test Framework',
+		type: 'ui',
+		retries: 0
+	}, {
+		name: 'fixture 1 > test',
+		status: 'passed',
+		location: { file: 'test/integration/data/testcafe-1.test.js' },
+		browser: 'edge',
+		tool: 'TestCafe 1 Test Reporting',
+		experience: 'Test Framework',
+		type: 'ui',
+		retries: 0
+	}, {
+		name: 'fixture 1 > skipped test',
+		status: 'skipped',
+		location: { file: 'test/integration/data/testcafe-1.test.js' },
+		browser: 'firefox',
+		tool: 'TestCafe 1 Test Reporting',
+		experience: 'Test Framework',
+		type: 'ui',
+		retries: 0
+	}, {
+		name: 'fixture 1 > skipped test',
+		status: 'skipped',
+		location: { file: 'test/integration/data/testcafe-1.test.js' },
+		browser: 'chrome',
+		tool: 'TestCafe 1 Test Reporting',
+		experience: 'Test Framework',
+		type: 'ui',
+		retries: 0
+	}, {
+		name: 'fixture 1 > skipped test',
+		status: 'skipped',
+		location: { file: 'test/integration/data/testcafe-1.test.js' },
+		browser: 'edge',
+		tool: 'TestCafe 1 Test Reporting',
+		experience: 'Test Framework',
+		type: 'ui',
+		retries: 0
+	}, {
+		name: 'fixture 1 > flaky test',
+		status: 'passed',
+		location: { file: 'test/integration/data/testcafe-1.test.js' },
+		browser: 'edge',
+		tool: 'TestCafe 1 Test Reporting',
+		experience: 'Test Framework',
+		type: 'ui',
+		retries: 2
+	}, {
+		name: 'fixture 1 > flaky test',
+		status: 'passed',
+		location: { file: 'test/integration/data/testcafe-1.test.js' },
+		browser: 'chrome',
+		tool: 'TestCafe 1 Test Reporting',
+		experience: 'Test Framework',
+		type: 'ui',
+		retries: 2
+	}, {
+		name: 'fixture 1 > flaky test',
+		status: 'passed',
+		location: { file: 'test/integration/data/testcafe-1.test.js' },
+		browser: 'firefox',
+		tool: 'TestCafe 1 Test Reporting',
+		experience: 'Test Framework',
+		type: 'ui',
+		retries: 2
+	}, {
+		name: 'fixture 1 > failed test',
+		status: 'failed',
+		location: { file: 'test/integration/data/testcafe-1.test.js' },
+		browser: 'firefox',
+		tool: 'TestCafe 1 Test Reporting',
+		experience: 'Test Framework',
+		type: 'ui',
+		retries: 3
+	}, {
+		name: 'fixture 1 > failed test',
+		status: 'failed',
+		location: { file: 'test/integration/data/testcafe-1.test.js' },
+		browser: 'edge',
+		tool: 'TestCafe 1 Test Reporting',
+		experience: 'Test Framework',
+		type: 'ui',
+		retries: 3
+	}, {
+		name: 'fixture 1 > failed test',
+		status: 'failed',
+		location: { file: 'test/integration/data/testcafe-1.test.js' },
+		browser: 'chrome',
+		tool: 'TestCafe 1 Test Reporting',
+		experience: 'Test Framework',
+		type: 'ui',
+		retries: 3
+	}, {
+		name: 'fixture 2 > test',
+		status: 'passed',
+		location: { file: 'test/integration/data/testcafe-2.test.js' },
+		browser: 'edge',
+		tool: 'TestCafe 2 Test Reporting',
+		experience: 'TestCafe 2 Test Framework',
+		type: 'integration',
+		retries: 0
+	}, {
+		name: 'fixture 2 > test',
+		status: 'passed',
+		location: { file: 'test/integration/data/testcafe-2.test.js' },
+		browser: 'chrome',
+		tool: 'TestCafe 2 Test Reporting',
+		experience: 'TestCafe 2 Test Framework',
+		type: 'integration',
+		retries: 0
+	}, {
+		name: 'fixture 2 > test',
+		status: 'passed',
+		location: { file: 'test/integration/data/testcafe-2.test.js' },
+		browser: 'firefox',
+		tool: 'TestCafe 2 Test Reporting',
+		experience: 'TestCafe 2 Test Framework',
+		type: 'integration',
+		retries: 0
+	}, {
+		name: 'fixture 2 > skipped test',
+		status: 'skipped',
+		location: { file: 'test/integration/data/testcafe-2.test.js' },
+		browser: 'edge',
+		tool: 'TestCafe 2 Test Reporting',
+		experience: 'TestCafe 2 Test Framework',
+		type: 'integration',
+		retries: 0
+	}, {
+		name: 'fixture 2 > skipped test',
+		status: 'skipped',
+		location: { file: 'test/integration/data/testcafe-2.test.js' },
+		browser: 'chrome',
+		tool: 'TestCafe 2 Test Reporting',
+		experience: 'TestCafe 2 Test Framework',
+		type: 'integration',
+		retries: 0
+	}, {
+		name: 'fixture 2 > skipped test',
+		status: 'skipped',
+		location: { file: 'test/integration/data/testcafe-2.test.js' },
+		browser: 'firefox',
+		tool: 'TestCafe 2 Test Reporting',
+		experience: 'TestCafe 2 Test Framework',
+		type: 'integration',
+		retries: 0
+	}, {
+		name: 'fixture 2 > flaky test',
+		status: 'passed',
+		location: { file: 'test/integration/data/testcafe-2.test.js' },
+		browser: 'chrome',
+		tool: 'TestCafe 2 Test Reporting',
+		experience: 'TestCafe 2 Test Framework',
+		type: 'integration',
+		retries: 2
+	}, {
+		name: 'fixture 2 > flaky test',
+		status: 'passed',
+		location: { file: 'test/integration/data/testcafe-2.test.js' },
+		browser: 'edge',
+		tool: 'TestCafe 2 Test Reporting',
+		experience: 'TestCafe 2 Test Framework',
+		type: 'integration',
+		retries: 2
+	}, {
+		name: 'fixture 2 > flaky test',
+		status: 'passed',
+		location: { file: 'test/integration/data/testcafe-2.test.js' },
+		browser: 'firefox',
+		tool: 'TestCafe 2 Test Reporting',
+		experience: 'TestCafe 2 Test Framework',
+		type: 'integration',
+		retries: 2
+	}, {
+		name: 'fixture 2 > failed test',
+		status: 'failed',
+		location: { file: 'test/integration/data/testcafe-2.test.js' },
+		browser: 'firefox',
+		tool: 'TestCafe 2 Test Reporting',
+		experience: 'TestCafe 2 Test Framework',
+		type: 'integration',
+		retries: 3
+	}, {
+		name: 'fixture 2 > failed test',
+		status: 'failed',
+		location: { file: 'test/integration/data/testcafe-2.test.js' },
+		browser: 'chrome',
+		tool: 'TestCafe 2 Test Reporting',
+		experience: 'TestCafe 2 Test Framework',
+		type: 'integration',
+		retries: 3
+	}, {
+		name: 'fixture 2 > failed test',
+		status: 'failed',
+		location: { file: 'test/integration/data/testcafe-2.test.js' },
+		browser: 'edge',
+		tool: 'TestCafe 2 Test Reporting',
+		experience: 'TestCafe 2 Test Framework',
+		type: 'integration',
+		retries: 3
+	}]
+};

--- a/test/integration/data/validation/test-report-web-test-runner.js
+++ b/test/integration/data/validation/test-report-web-test-runner.js
@@ -118,3 +118,120 @@ export const testReportV1Partial = {
 		retries: 0
 	}]
 };
+export const testReportV2Partial = {
+	version: 2,
+	summary: {
+		status: 'failed',
+		framework: '@web/test-runner',
+		count: { passed: 4, failed: 4, skipped: 4, flaky: 0 }
+	},
+	details: [{
+		name: 'reporter tests 1 > test',
+		status: 'passed',
+		location: { file: 'test/integration/data/web-test-runner-1.test.js' },
+		browser: 'chrome',
+		tool: 'WebTestRunner 1 Test Reporting',
+		experience: 'WebTestRunner 1 Test Framework',
+		type: 'integration',
+		retries: 0
+	}, {
+		name: 'reporter tests 1 > skipped test',
+		status: 'skipped',
+		location: { file: 'test/integration/data/web-test-runner-1.test.js' },
+		browser: 'chrome',
+		tool: 'WebTestRunner 1 Test Reporting',
+		experience: 'WebTestRunner 1 Test Framework',
+		type: 'integration',
+		retries: 0
+	}, {
+		name: 'reporter tests 1 > failed test',
+		status: 'failed',
+		location: { file: 'test/integration/data/web-test-runner-1.test.js' },
+		browser: 'chrome',
+		tool: 'WebTestRunner 1 Test Reporting',
+		experience: 'WebTestRunner 1 Test Framework',
+		type: 'integration',
+		retries: 0
+	}, {
+		name: '[group 1] > reporter tests 2 > test',
+		status: 'passed',
+		location: { file: 'test/integration/data/web-test-runner-2.test.js' },
+		browser: 'chromium',
+		tool: 'Test Reporting',
+		experience: 'WebTestRunner 2 Test Framework',
+		type: 'accessibility',
+		retries: 0
+	}, {
+		name: '[group 1] > reporter tests 2 > skipped test',
+		status: 'skipped',
+		location: { file: 'test/integration/data/web-test-runner-2.test.js' },
+		browser: 'chromium',
+		tool: 'Test Reporting',
+		experience: 'WebTestRunner 2 Test Framework',
+		type: 'accessibility',
+		retries: 0
+	}, {
+		name: '[group 1] > reporter tests 2 > failed test',
+		status: 'failed',
+		location: { file: 'test/integration/data/web-test-runner-2.test.js' },
+		browser: 'chromium',
+		tool: 'Test Reporting',
+		experience: 'WebTestRunner 2 Test Framework',
+		type: 'accessibility',
+		retries: 0
+	}, {
+		name: '[group 1] > reporter tests 2 > test',
+		status: 'passed',
+		location: { file: 'test/integration/data/web-test-runner-2.test.js' },
+		browser: 'firefox',
+		tool: 'Test Reporting',
+		experience: 'WebTestRunner 2 Test Framework',
+		type: 'accessibility',
+		retries: 0
+	}, {
+		name: '[group 1] > reporter tests 2 > skipped test',
+		status: 'skipped',
+		location: { file: 'test/integration/data/web-test-runner-2.test.js' },
+		browser: 'firefox',
+		tool: 'Test Reporting',
+		experience: 'WebTestRunner 2 Test Framework',
+		type: 'accessibility',
+		retries: 0
+	}, {
+		name: '[group 1] > reporter tests 2 > failed test',
+		status: 'failed',
+		location: { file: 'test/integration/data/web-test-runner-2.test.js' },
+		browser: 'firefox',
+		tool: 'Test Reporting',
+		experience: 'WebTestRunner 2 Test Framework',
+		type: 'accessibility',
+		retries: 0
+	}, {
+		name: '[group 2] > reporter tests 1 > test',
+		status: 'passed',
+		location: { file: 'test/integration/data/web-test-runner-1.test.js' },
+		browser: 'webkit',
+		tool: 'WebTestRunner 1 Test Reporting',
+		experience: 'WebTestRunner 1 Test Framework',
+		type: 'integration',
+		retries: 0
+	}, {
+		name: '[group 2] > reporter tests 1 > skipped test',
+		status: 'skipped',
+		location: { file: 'test/integration/data/web-test-runner-1.test.js' },
+		browser: 'webkit',
+		tool: 'WebTestRunner 1 Test Reporting',
+		experience: 'WebTestRunner 1 Test Framework',
+		type: 'integration',
+		retries: 0
+	}, {
+		name: '[group 2] > reporter tests 1 > failed test',
+		status: 'failed',
+		location: { file: 'test/integration/data/web-test-runner-1.test.js' },
+		browser: 'webkit',
+		tool: 'WebTestRunner 1 Test Reporting',
+		experience: 'WebTestRunner 1 Test Framework',
+		type: 'integration',
+		retries: 0
+	}]
+};

--- a/test/integration/report-validation.test.js
+++ b/test/integration/report-validation.test.js
@@ -3,10 +3,10 @@ import chaiSubset from 'chai-subset';
 import { getOperatingSystemType } from '../../src/helpers/system.cjs';
 import { hasContext } from '../../src/helpers/github.cjs';
 import { Report } from '../../src/helpers/report.cjs';
-import { testReportV1Partial as testReportV1PartialMocha } from './data/validation/test-report-mocha.js';
-import { testReportV1Partial as testReportV1PartialPlaywright } from './data/validation/test-report-playwright.js';
-import { testReportV1Partial as testReportV1PartialTestCafe } from './data/validation/test-report-testcafe.js';
-import { testReportV1Partial as testReportV1PartialWebTestRunner } from './data/validation/test-report-web-test-runner.js';
+import { testReportV2Partial as testReportV2PartialMocha } from './data/validation/test-report-mocha.js';
+import { testReportV2Partial as testReportV2PartialPlaywright } from './data/validation/test-report-playwright.js';
+import { testReportV2Partial as testReportV2PartialTestCafe } from './data/validation/test-report-testcafe.js';
+import { testReportV2Partial as testReportV2PartialWebTestRunner } from './data/validation/test-report-web-test-runner.js';
 
 use(chaiSubset);
 
@@ -26,19 +26,19 @@ const testContext = {
 const reportTests = [{
 	name: 'mocha',
 	path: './d2l-test-report-mocha.json',
-	expected: testReportV1PartialMocha
+	expected: testReportV2PartialMocha
 }, {
 	name: 'playwright',
 	path: './d2l-test-report-playwright.json',
-	expected: testReportV1PartialPlaywright
+	expected: testReportV2PartialPlaywright
 }, {
 	name: '@web/test-runner',
 	path: './d2l-test-report-web-test-runner.json',
-	expected: testReportV1PartialWebTestRunner
+	expected: testReportV2PartialWebTestRunner
 }, {
 	name: 'testcafe',
 	path: './d2l-test-report-testcafe.json',
-	expected: testReportV1PartialTestCafe
+	expected: testReportV2PartialTestCafe
 }];
 
 describe('report validation', () => {
@@ -73,7 +73,7 @@ describe('report validation', () => {
 				const { summary, details } = report;
 
 				expect(summary.operatingSystem).to.eq(getOperatingSystemType());
-				expect(summary.totalDuration).to.be.above(0);
+				expect(summary.duration.total).to.be.above(0);
 
 				const summaryStarted = new Date(summary.started);
 
@@ -83,11 +83,11 @@ describe('report validation', () => {
 				for (const detail of details) {
 					const detailStarted = new Date(detail.started);
 
-					expect(detail.duration).to.be.at.least(0);
-					expect(detail.totalDuration).to.be.at.least(0);
-					expect(detail.totalDuration).to.be.at.least(detail.duration);
-					expect(detail.duration).to.be.at.most(summary.totalDuration);
-					expect(detail.totalDuration).to.be.at.most(summary.totalDuration);
+					expect(detail.duration.final).to.be.at.least(0);
+					expect(detail.duration.total).to.be.at.least(0);
+					expect(detail.duration.total).to.be.at.least(detail.duration.final);
+					expect(detail.duration.final).to.be.at.most(summary.duration.total);
+					expect(detail.duration.total).to.be.at.most(summary.duration.total);
 					expect(detailStarted).to.be.at.most(now);
 					expect(detailStarted).to.be.at.least(nowMinus30Minutes);
 					expect(detailStarted).to.be.at.least(summaryStarted);

--- a/test/unit/report.test.js
+++ b/test/unit/report.test.js
@@ -130,7 +130,7 @@ describe('report', () => {
 			const wrapper = () => report = (new Report(testReportPath));
 
 			expect(wrapper).to.not.throw();
-			expect(report.toJSON()).to.deep.equal(testReportV1Full);
+			expect(report.toJSON()).to.deep.not.equal(testReportV1Full);
 			expect(report.getContext()).to.deep.equal(testContext);
 		});
 
@@ -147,7 +147,7 @@ describe('report', () => {
 				const wrapper = () => report = new Report(testReportPath, reportOptions);
 
 				expect(wrapper).to.not.throw();
-				expect(report.toJSON()).to.deep.equal(testReportV1FullOther);
+				expect(report.toJSON()).to.deep.not.equal(testReportV1FullOther);
 				expect(report.getContext()).to.deep.equal(testContextOther);
 			});
 
@@ -157,10 +157,10 @@ describe('report', () => {
 				const reportOptions = { context: testContextOther };
 				let report;
 
-				const wrapper = () => report = (new Report(testReportPath, reportOptions));
+				const wrapper = () => report = new Report(testReportPath, reportOptions);
 
 				expect(wrapper).to.not.throw();
-				expect(report.toJSON()).to.deep.equal(testReportV1Full);
+				expect(report.toJSON()).to.deep.not.equal(testReportV1Full);
 				expect(report.getContext()).to.deep.equal(testContext);
 			});
 		});
@@ -175,10 +175,10 @@ describe('report', () => {
 				};
 				let report;
 
-				const wrapper = () => report = (new Report(testReportPath, reportOptions));
+				const wrapper = () => report = new Report(testReportPath, reportOptions);
 
 				expect(wrapper).to.not.throw();
-				expect(report.toJSON()).to.deep.equal(testReportV1FullOther);
+				expect(report.toJSON()).to.deep.not.equal(testReportV1FullOther);
 				expect(report.getContext()).to.deep.equal(testContextOther);
 			});
 
@@ -188,10 +188,10 @@ describe('report', () => {
 				const reportOptions = { context: testContextOther };
 				let report;
 
-				const wrapper = () => report = (new Report(testReportPath, reportOptions));
+				const wrapper = () => report = new Report(testReportPath, reportOptions);
 
 				expect(wrapper).to.not.throw();
-				expect(report.toJSON()).to.deep.equal(testReportV1FullOther);
+				expect(report.toJSON()).to.deep.not.equal(testReportV1FullOther);
 				expect(report.getContext()).to.deep.equal(testContextOther);
 			});
 		});
@@ -206,10 +206,10 @@ describe('report', () => {
 				};
 				let report;
 
-				const wrapper = () => report = (new Report(testReportPath, reportOptions));
+				const wrapper = () => report = new Report(testReportPath, reportOptions);
 
 				expect(wrapper).to.not.throw();
-				expect(report.toJSON()).to.deep.equal(testReportV1FullOther);
+				expect(report.toJSON()).to.deep.not.equal(testReportV1FullOther);
 				expect(report.getContext()).to.deep.equal(testContextOther);
 			});
 
@@ -219,10 +219,10 @@ describe('report', () => {
 				const reportOptions = { context: testContextOther };
 				let report;
 
-				const wrapper = () => report = (new Report(testReportPath, reportOptions));
+				const wrapper = () => report = new Report(testReportPath, reportOptions);
 
 				expect(wrapper).to.not.throw();
-				expect(report.toJSON()).to.deep.equal(testReportV1FullOther);
+				expect(report.toJSON()).to.deep.not.equal(testReportV1FullOther);
 				expect(report.getContext()).to.deep.equal(testContextOther);
 			});
 		});


### PR DESCRIPTION
This adds the v2 schema and implements the auto upgrade path in the `Report` construct. Right now the `ReportBuilder` doesn't output the new `v2` format as I want to roll that out separately. This allows for the additional data wanted in #162, #156, #149 and #29 to be added (all net new data is optional in `v2`). This new data will come once the `ReportBuilder` is upgraded (will be done in another PR). Tests have been updated to test against the `v2` format. Want to look at running tests against `v1` as well possibly so I've left the partial test data in for now. Will do more test updates in a future PR.

This will require changes in the action so the automatic PR that will get opened will fail CI. That's ok though. I'll make the adjustments there.

BREAKING CHANGE: Add a `v2` schema of the report format. `Report` object now auto upgrades any previous format to the `v2` format upon loading.