### PR TITLE
fix: v2 schema incorrect `error` property

### DIFF
--- a/schemas/report/v2.json
+++ b/schemas/report/v2.json
@@ -189,7 +189,26 @@
             "minimum": 0
           },
           "error": {
-            "$ref": "#/$defs/nonEmptyUnpaddedString"
+            "type": "object",
+            "properties": {
+              "message": {
+                "$ref": "#/$defs/nonEmptyUnpaddedString"
+              },
+              "file": {
+                "$ref": "#/$defs/nonEmptyUnpaddedString"
+              },
+              "line": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "column": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "message"
+            ]
           }
         },
         "required": [


### PR DESCRIPTION
This was incorrect. Updating to include proper properties. I'm not bumping the schema version here since nothing is emitting or consuming any error property stuff yet.