### PR TITLE
fix: make setting of `duration` of `0` explicit for some reporters

### DIFF
--- a/src/helpers/report-builder.cjs
+++ b/src/helpers/report-builder.cjs
@@ -187,8 +187,6 @@ class ReportDetailBuilder extends ReportBuilderBase {
 
 		this._reportConfiguration = reportConfiguration;
 
-		this._setNestedProperty('duration', 'total', 0);
-		this._setNestedProperty('duration', 'final', 0);
 		this._setProperty('retries', 0);
 	}
 
@@ -273,6 +271,18 @@ class ReportDetailBuilder extends ReportBuilderBase {
 	addDuration(duration) {
 		this._setNestedProperty('duration', 'final', duration, { override: true });
 		this._accumulateNestedProperty('duration', 'total', duration);
+
+		return this;
+	}
+
+	setDurationTotal(duration, options) {
+		this._setNestedProperty('duration', 'total', duration, options);
+
+		return this;
+	}
+
+	setDurationFinal(duration, options) {
+		this._setNestedProperty('duration', 'final', duration, options);
 
 		return this;
 	}

--- a/src/reporters/mocha.cjs
+++ b/src/reporters/mocha.cjs
@@ -103,7 +103,10 @@ class TestReportingMochaReporter extends Spec {
 		const detail = this._report.getDetail(id);
 
 		if (state === 'pending') {
-			detail.setSkipped();
+			detail
+				.setSkipped()
+				.setDurationFinal(0)
+				.setDurationTotal(0);
 		} else {
 			detail.addDuration(duration);
 

--- a/src/reporters/web-test-runner.js
+++ b/src/reporters/web-test-runner.js
@@ -60,6 +60,10 @@ export function reporter(options = {}) {
 
 			if (duration !== undefined) {
 				detail.addDuration(duration);
+			} else {
+				detail
+					.setDurationFinal(0)
+					.setDurationTotal(0);
 			}
 		}
 	};

--- a/test/integration/data/mocha-1.test.js
+++ b/test/integration/data/mocha-1.test.js
@@ -1,13 +1,13 @@
-const delay = (ms = 100) => {
+const delay = (ms = 50) => {
 	return new Promise(resolve => setTimeout(resolve, ms));
 };
 
 describe('reporter tests 1', () => {
 	let count = 0;
 
-	before(async() => { await delay(1000); });
+	before(async() => { await delay(250); });
 
-	beforeEach(async() => { await delay(1000); });
+	beforeEach(async() => { await delay(250); });
 
 	it('test', async() => { await delay(); });
 
@@ -27,7 +27,7 @@ describe('reporter tests 1', () => {
 
 	it('failed test', () => { throw new Error('fail'); });
 
-	afterEach(async() => { await delay(1000); });
+	afterEach(async() => { await delay(250); });
 
-	after(async() => { await delay(1000); });
+	after(async() => { await delay(250); });
 });

--- a/test/integration/data/mocha-2.test.js
+++ b/test/integration/data/mocha-2.test.js
@@ -1,13 +1,13 @@
-const delay = (ms = 100) => {
+const delay = (ms = 50) => {
 	return new Promise(resolve => setTimeout(resolve, ms));
 };
 
 describe('reporter tests 2', () => {
 	let count = 0;
 
-	before(async() => { await delay(1000); });
+	before(async() => { await delay(250); });
 
-	beforeEach(async() => { await delay(1000); });
+	beforeEach(async() => { await delay(250); });
 
 	it('test', async() => { await delay(); });
 
@@ -27,7 +27,7 @@ describe('reporter tests 2', () => {
 
 	it('failed test', () => { throw new Error('fail'); });
 
-	afterEach(async() => { await delay(1000); });
+	afterEach(async() => { await delay(250); });
 
-	after(async() => { await delay(1000); });
+	after(async() => { await delay(250); });
 });

--- a/test/integration/data/mocha-3.test.js
+++ b/test/integration/data/mocha-3.test.js
@@ -1,13 +1,13 @@
-const delay = (ms = 100) => {
+const delay = (ms = 50) => {
 	return new Promise(resolve => setTimeout(resolve, ms));
 };
 
 describe('reporter tests 3', () => {
 	let count = 0;
 
-	before(async() => { await delay(1000); });
+	before(async() => { await delay(250); });
 
-	beforeEach(async() => { await delay(1000); });
+	beforeEach(async() => { await delay(250); });
 
 	it('test', async() => { await delay(); });
 
@@ -27,7 +27,7 @@ describe('reporter tests 3', () => {
 
 	it('failed test', () => { throw new Error('fail'); });
 
-	afterEach(async() => { await delay(1000); });
+	afterEach(async() => { await delay(250); });
 
-	after(async() => { await delay(1000); });
+	after(async() => { await delay(250); });
 });

--- a/test/integration/data/playwright-1.test.js
+++ b/test/integration/data/playwright-1.test.js
@@ -1,13 +1,13 @@
 import { test } from '@playwright/test';
 
-const delay = (ms = 100) => {
+const delay = (ms = 50) => {
 	return new Promise(resolve => setTimeout(resolve, ms));
 };
 
 test.describe('reporter tests 1', () => {
-	test.beforeAll(async() => { await delay(1000); });
+	test.beforeAll(async() => { await delay(250); });
 
-	test.beforeEach(async() => { await delay(1000); });
+	test.beforeEach(async() => { await delay(250); });
 
 	test('test', async() => { await delay(); });
 
@@ -26,7 +26,7 @@ test.describe('reporter tests 1', () => {
 
 	test('failed test', () => { throw new Error('fail'); });
 
-	test.afterEach(async() => { await delay(1000); });
+	test.afterEach(async() => { await delay(250); });
 
-	test.afterAll(async() => { await delay(1000); });
+	test.afterAll(async() => { await delay(250); });
 });

--- a/test/integration/data/playwright-2.test.js
+++ b/test/integration/data/playwright-2.test.js
@@ -1,13 +1,13 @@
 import { test } from '@playwright/test';
 
-const delay = (ms = 100) => {
+const delay = (ms = 50) => {
 	return new Promise(resolve => setTimeout(resolve, ms));
 };
 
 test.describe('reporter tests 2', () => {
-	test.beforeAll(async() => { await delay(1000); });
+	test.beforeAll(async() => { await delay(250); });
 
-	test.beforeEach(async() => { await delay(1000); });
+	test.beforeEach(async() => { await delay(250); });
 
 	test('test', async() => { await delay(); });
 
@@ -26,7 +26,7 @@ test.describe('reporter tests 2', () => {
 
 	test('failed test', () => { throw new Error('fail'); });
 
-	test.afterEach(async() => { await delay(1000); });
+	test.afterEach(async() => { await delay(250); });
 
-	test.afterAll(async() => { await delay(1000); });
+	test.afterAll(async() => { await delay(250); });
 });

--- a/test/integration/data/playwright-3.test.js
+++ b/test/integration/data/playwright-3.test.js
@@ -1,13 +1,13 @@
 import { test } from '@playwright/test';
 
-const delay = (ms = 100) => {
+const delay = (ms = 50) => {
 	return new Promise(resolve => setTimeout(resolve, ms));
 };
 
 test.describe('reporter tests 3', () => {
-	test.beforeAll(async() => { await delay(1000); });
+	test.beforeAll(async() => { await delay(250); });
 
-	test.beforeEach(async() => { await delay(1000); });
+	test.beforeEach(async() => { await delay(250); });
 
 	test('test', async() => { await delay(); });
 
@@ -26,7 +26,7 @@ test.describe('reporter tests 3', () => {
 
 	test('failed test', () => { throw new Error('fail'); });
 
-	test.afterEach(async() => { await delay(1000); });
+	test.afterEach(async() => { await delay(250); });
 
-	test.afterAll(async() => { await delay(1000); });
+	test.afterAll(async() => { await delay(250); });
 });

--- a/test/integration/data/web-test-runner-1.test.js
+++ b/test/integration/data/web-test-runner-1.test.js
@@ -1,11 +1,11 @@
-const delay = (ms = 100) => {
+const delay = (ms = 50) => {
 	return new Promise(resolve => setTimeout(resolve, ms));
 };
 
 describe('reporter tests 1', () => {
-	before(async() => { await delay(1000); });
+	before(async() => { await delay(250); });
 
-	beforeEach(async() => { await delay(1000); });
+	beforeEach(async() => { await delay(250); });
 
 	it('test', async() => { await delay(); });
 
@@ -13,7 +13,7 @@ describe('reporter tests 1', () => {
 
 	it('failed test', () => { throw new Error('fail'); });
 
-	afterEach(async() => { await delay(1000); });
+	afterEach(async() => { await delay(250); });
 
-	after(async() => { await delay(1000); });
+	after(async() => { await delay(250); });
 });

--- a/test/integration/data/web-test-runner-2.test.js
+++ b/test/integration/data/web-test-runner-2.test.js
@@ -1,11 +1,11 @@
-const delay = (ms = 100) => {
+const delay = (ms = 50) => {
 	return new Promise(resolve => setTimeout(resolve, ms));
 };
 
 describe('reporter tests 2', () => {
-	before(async() => { await delay(1000); });
+	before(async() => { await delay(250); });
 
-	beforeEach(async() => { await delay(1000); });
+	beforeEach(async() => { await delay(250); });
 
 	it('test', async() => { await delay(); });
 
@@ -13,7 +13,7 @@ describe('reporter tests 2', () => {
 
 	it('failed test', () => { throw new Error('fail'); });
 
-	afterEach(async() => { await delay(1000); });
+	afterEach(async() => { await delay(250); });
 
-	after(async() => { await delay(1000); });
+	after(async() => { await delay(250); });
 });

--- a/test/integration/data/web-test-runner-3.test.js
+++ b/test/integration/data/web-test-runner-3.test.js
@@ -1,11 +1,11 @@
-const delay = (ms = 100) => {
+const delay = (ms = 50) => {
 	return new Promise(resolve => setTimeout(resolve, ms));
 };
 
 describe('reporter tests 3', () => {
-	before(async() => { await delay(1000); });
+	before(async() => { await delay(250); });
 
-	beforeEach(async() => { await delay(1000); });
+	beforeEach(async() => { await delay(250); });
 
 	it('test', async() => { await delay(); });
 
@@ -13,7 +13,7 @@ describe('reporter tests 3', () => {
 
 	it('failed test', () => { throw new Error('fail'); });
 
-	afterEach(async() => { await delay(1000); });
+	afterEach(async() => { await delay(250); });
 
-	after(async() => { await delay(1000); });
+	after(async() => { await delay(250); });
 });

--- a/test/integration/report-validation.test.js
+++ b/test/integration/report-validation.test.js
@@ -86,11 +86,12 @@ describe('report validation', () => {
 				for (const detail of details) {
 					const detailStarted = new Date(detail.started);
 
-					expect(detail.duration.final).to.be.at.least(0);
 					expect(detail.duration.total).to.be.at.least(0);
 
 					if (['passed', 'flaky'].includes(detail.status)) {
 						expect(detail.duration.final).to.be.gt(0);
+					} else {
+						expect(detail.duration.final).to.be.at.least(0);
 					}
 
 					expect(detail.duration.total).to.be.at.least(detail.duration.final);


### PR DESCRIPTION
This removed the implicit setting of the detail duration values to 0 in the constructor. Will cause invalid report if those values don't get set anywhere. Better for tracking down issues. Tests were starting to take too long as well so minimized time waiting.