### PR TITLE
Run updates more frequently

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,7 +1,7 @@
 name: Update Dependencies
 on:
   schedule:
-    - cron: '00 9 * * 1' # Mon 5:00am EDT/4:00am EST
+    - cron: '00 9 * * 1-5' # Mon-Fri 5:00am EDT/4:00am EST
   workflow_dispatch: # manual trigger
 env:
   FORCE_COLOR: 3


### PR DESCRIPTION
Now that this workflow is mainly automated and we will get added to stuff only on errors let's increase how often it happens. Keeps things fresh.