### PR TITLE
Add ignore rule for `eslint` for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-patch']
+      - dependency-name: eslint
+        versions: '>= 9'
     groups:
       testcafe:
         dependency-type: production


### PR DESCRIPTION
There are issues with `eslint` updates for version `9` and greater. Ignore them for now to stop spam Prs