### PR TITLE
fix: don't throw errors if config is not loaded

### DIFF
--- a/src/helpers/report-builder.cjs
+++ b/src/helpers/report-builder.cjs
@@ -196,6 +196,10 @@ class ReportDetailBuilder extends ReportBuilderBase {
 
 		this._setNestedProperty('location', 'file', filePath, options);
 
+		if (!this._reportConfiguration) {
+			return this;
+		}
+
 		const { type, tool, experience } = this._reportConfiguration.getTaxonomy(filePath);
 
 		this._setProperty('type', type, options);
@@ -318,6 +322,10 @@ class ReportBuilder extends ReportBuilderBase {
 	}
 
 	ignoreFilePath(filePath) {
+		if (!this._reportConfiguration) {
+			return false;
+		}
+
 		return this._reportConfiguration.ignoreFilePath(filePath);
 	}
 


### PR DESCRIPTION
If the config fails to load it's `null`, add some `null` checks to avoid downstream error messages being throw. Noticed this in https://github.com/Brightspace/playwright-ui-automation/pull/1641.