### PR TITLE
fix: handle issues with initializing the report builder (QE-251)

### DIFF
--- a/src/reporters/mocha.cjs
+++ b/src/reporters/mocha.cjs
@@ -34,7 +34,17 @@ class TestReportingMochaReporter extends Spec {
 		const { reporterOptions = {} } = options;
 
 		this._logger = new MochaLogger();
-		this._report = new ReportBuilder('mocha', this._logger, reporterOptions);
+
+		try {
+			const report = new ReportBuilder('mocha', this._logger, reporterOptions);
+
+			this._report = report;
+		} catch ({ message }) {
+			this._logger.error('Failed to initialize D2L test report builder, report will not be generated');
+			this._logger.error(message);
+
+			return;
+		}
 
 		runner
 			.once(EVENT_RUN_BEGIN, () => this._onRunBegin(stats))

--- a/src/reporters/playwright.js
+++ b/src/reporters/playwright.js
@@ -55,7 +55,15 @@ export default class Reporter {
 		}
 
 		this._logger = new PlaywrightLogger();
-		this._report = new ReportBuilder('playwright', this._logger, this._options);
+
+		try {
+			this._report = new ReportBuilder('playwright', this._logger, this._options);
+		} catch ({ message }) {
+			this._logger.error('Failed to initialize D2L test report builder, report will not be generated');
+			this._logger.error(message);
+
+			return;
+		}
 
 		this._report
 			.getSummary()
@@ -63,6 +71,10 @@ export default class Reporter {
 	}
 
 	onTestEnd(test, result) {
+		if (!this._report || !this._hasTests) {
+			return;
+		}
+
 		const { timeout, location: { file, line, column } } = test;
 
 		if (this._report.ignoreFilePath(file)) {
@@ -103,7 +115,7 @@ export default class Reporter {
 	}
 
 	onEnd(result) {
-		if (!this._hasTests) {
+		if (!this._report || !this._hasTests) {
 			return;
 		}
 
@@ -123,7 +135,7 @@ export default class Reporter {
 	}
 
 	async onExit() {
-		if (!this._hasTests) {
+		if (!this._report || !this._hasTests) {
 			return;
 		}
 

--- a/src/reporters/web-test-runner.js
+++ b/src/reporters/web-test-runner.js
@@ -19,12 +19,27 @@ const makeDetailId = (sessionId, file, name) => {
 	return `${sessionId}/${file}/${name}`;
 };
 
+const nullReporter = {
+	start() {},
+	stop() {}
+};
+
 export function reporter(options = {}) {
 	let overallStarted;
 	let testConfig;
 	const sessionStarts = new Map();
 	const logger = new WebTestRunnerLogger();
-	const report = new ReportBuilder('@web/test-runner', logger, options);
+	let report;
+
+	try {
+		report = new ReportBuilder('@web/test-runner', logger, options);
+	} catch ({ message }) {
+		logger.error('Failed to initialize D2L test report builder, report will not be generated');
+		logger.error(message);
+
+		return nullReporter;
+	}
+
 	const summary = report
 		.getSummary()
 		.addContext();


### PR DESCRIPTION
This is mainly to handle issues with config file loading. This will just not generate a report if it fails to load the config or find any of the needed start data. Found this while doing some other integrations.

https://desire2learn.atlassian.net/browse/QE-251