### PR TITLE
feat: add in custom error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@web/test-runner-core": "^0.13",
         "ajv": "^8",
+        "ajv-errors": "^3",
         "ajv-formats": "^3",
         "chalk": "^5",
         "lodash": "^4",
@@ -1914,6 +1915,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.0.1"
       }
     },
     "node_modules/ajv-formats": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@web/test-runner-core": "^0.13",
     "ajv": "^8",
+    "ajv-errors": "^3",
     "ajv-formats": "^3",
     "chalk": "^5",
     "lodash": "^4",

--- a/schemas/report/v1.json
+++ b/schemas/report/v1.json
@@ -22,7 +22,7 @@
         },
         "lmsBuildNumber": {
           "type": "string",
-          "pattern": "([0-9]{2}\\.){2}[0-9]{1,2}\\.[0-9]{5}",
+          "pattern": "^([0-9]{2}\\.){2}[0-9]{1,2}\\.[0-9]{5}$",
           "errorMessage": {
             "pattern": "should be a valid LMS build number (XX.XX.XX.XXXXX)"
           }

--- a/schemas/report/v1.json
+++ b/schemas/report/v1.json
@@ -165,8 +165,8 @@
       "$schema": "https://json-schema.org/draft/2019-09/schema",
       "$id": "/test-reporting/schemas/report/v1/non-empty-unpadded-string.json",
       "type": "string",
-      "pattern": "^(?!\\s).+(?<!\\s)$",
       "minLength": 1,
+      "pattern": "^(?!\\s).+(?<!\\s)$",
       "errorMessage": {
         "pattern": "should be non-empty without leading or trailing whitespace"
       }

--- a/schemas/report/v1.json
+++ b/schemas/report/v1.json
@@ -22,7 +22,10 @@
         },
         "lmsBuildNumber": {
           "type": "string",
-          "pattern": "([0-9]{2}\\.){2}[0-9]{1,2}\\.[0-9]{5}"
+          "pattern": "([0-9]{2}\\.){2}[0-9]{1,2}\\.[0-9]{5}",
+          "errorMessage": {
+            "pattern": "should be a valid LMS build number (XX.XX.XX.XXXXX)"
+          }
         },
         "lmsInstanceUrl": {
           "type": "string",
@@ -162,8 +165,11 @@
       "$schema": "https://json-schema.org/draft/2019-09/schema",
       "$id": "/test-reporting/schemas/report/v1/non-empty-unpadded-string.json",
       "type": "string",
+      "pattern": "^(?!\\s).+(?<!\\s)$",
       "minLength": 1,
-      "pattern": "^(?!\\s).+(?<!\\s)$"
+      "errorMessage": {
+        "pattern": "should be non-empty without leading or trailing whitespace"
+      }
     },
     "context": {
       "$schema": "https://json-schema.org/draft/2019-09/schema",
@@ -194,7 +200,10 @@
           "type": "string",
           "minLength": 40,
           "maxLength": 40,
-          "pattern": "[A-Fa-f0-9]+"
+          "pattern": "^[A-Fa-f0-9]+$",
+          "errorMessage": {
+            "pattern": "should be a git hash"
+          }
         }
       },
       "required": [
@@ -210,7 +219,10 @@
         "gitHubAllowedCharactersString": {
           "type": "string",
           "minLength": 1,
-          "pattern": "[A-Za-z0-9_.-]+"
+          "pattern": "^[A-Za-z0-9_.-]+$",
+          "errorMessage": {
+            "pattern": "should be a valid github string, must include only alpha numeric, ., _, or - characters"
+          }
         }
       }
     }

--- a/schemas/report/v2.json
+++ b/schemas/report/v2.json
@@ -25,7 +25,10 @@
           "properties": {
             "buildNumber": {
               "type": "string",
-              "pattern": "([0-9]{2}\\.){2}[0-9]{1,2}\\.[0-9]{5}"
+              "pattern": "([0-9]{2}\\.){2}[0-9]{1,2}\\.[0-9]{5}",
+              "errorMessage": {
+                "pattern": "should be a valid LMS build number (XX.XX.XX.XXXXX)"
+              }
             },
             "instanceUrl": {
               "type": "string",
@@ -211,8 +214,11 @@
       "$schema": "https://json-schema.org/draft/2019-09/schema",
       "$id": "/test-reporting/schemas/report/v2/non-empty-unpadded-string.json",
       "type": "string",
+      "pattern": "^(?!\\s).+(?<!\\s)$",
       "minLength": 1,
-      "pattern": "^(?!\\s).+(?<!\\s)$"
+      "errorMessage": {
+        "pattern": "should be non-empty without leading or trailing whitespace"
+      }
     },
     "context": {
       "$schema": "https://json-schema.org/draft/2019-09/schema",
@@ -258,7 +264,10 @@
               "type": "string",
               "minLength": 40,
               "maxLength": 40,
-              "pattern": "[A-Fa-f0-9]+"
+              "pattern": "^[A-Fa-f0-9]+$",
+              "errorMessage": {
+                "pattern": "should be a git hash"
+              }
             }
           },
           "required": [
@@ -275,7 +284,10 @@
         "gitHubAllowedCharactersString": {
           "type": "string",
           "minLength": 1,
-          "pattern": "[A-Za-z0-9_.-]+"
+          "pattern": "[A-Za-z0-9_.-]+",
+          "errorMessage": {
+            "pattern": "should be a valid github string, must include only alpha numeric, ., _, or - characters"
+          }
         }
       }
     }

--- a/schemas/report/v2.json
+++ b/schemas/report/v2.json
@@ -284,7 +284,7 @@
         "gitHubAllowedCharactersString": {
           "type": "string",
           "minLength": 1,
-          "pattern": "[A-Za-z0-9_.-]+",
+          "pattern": "^[A-Za-z0-9_.-]+$",
           "errorMessage": {
             "pattern": "should be a valid github string, must include only alpha numeric, ., _, or - characters"
           }

--- a/schemas/report/v2.json
+++ b/schemas/report/v2.json
@@ -25,7 +25,7 @@
           "properties": {
             "buildNumber": {
               "type": "string",
-              "pattern": "([0-9]{2}\\.){2}[0-9]{1,2}\\.[0-9]{5}",
+              "pattern": "^([0-9]{2}\\.){2}[0-9]{1,2}\\.[0-9]{5}$",
               "errorMessage": {
                 "pattern": "should be a valid LMS build number (XX.XX.XX.XXXXX)"
               }

--- a/src/helpers/report-configuration.cjs
+++ b/src/helpers/report-configuration.cjs
@@ -48,7 +48,7 @@ class ReportConfiguration {
 		if (!validateReportConfigurationV1Ajv(reportConfiguration)) {
 			const { errors } = validateReportConfigurationV1Ajv;
 
-			throw new Error(formatErrorAjv('report configuration', errors));
+			throw new Error(formatErrorAjv(errors, { dataVar: 'report configuration' }));
 		}
 
 		this._reportConfigurationPath = reportConfigurationPath;

--- a/src/helpers/report.cjs
+++ b/src/helpers/report.cjs
@@ -49,7 +49,7 @@ const validateReport = (report, dataVar = 'report') => {
 	}
 
 	if (errors && errors.length !== 0) {
-		throw new Error(formatErrorAjv(dataVar, errors));
+		throw new Error(formatErrorAjv(errors, { dataVar }));
 	}
 };
 

--- a/src/helpers/schema.cjs
+++ b/src/helpers/schema.cjs
@@ -1,20 +1,20 @@
 const Ajv = require('ajv/dist/2019');
 const addFormats = require('ajv-formats');
+const addErrors = require('ajv-errors');
 
 const latestReportSchema = require('../../schemas/report/v2.json');
 const ajv = new Ajv({
 	verbose: true,
 	strict: true,
-	allErrors: false,
-	schemas: [
-		require('../../schemas/report-configuration/v1.json'),
-		require('../../schemas/report/v1.json'),
-		latestReportSchema
-	]
+	allErrors: true
 });
 
+addErrors(ajv);
 addFormats(ajv, ['date-time', 'uri', 'uuid']);
 
+ajv.addSchema(require('../../schemas/report-configuration/v1.json'));
+ajv.addSchema(require('../../schemas/report/v1.json'));
+ajv.addSchema(latestReportSchema);
 ajv.addSchema({
 	$schema: 'https://json-schema.org/draft/2019-09/schema',
 	$id: '/test-reporting/schemas/report/v1/context/loose.json',
@@ -35,27 +35,10 @@ const validateReportV1ContextAjv = ajv.getSchema('/test-reporting/schemas/report
 const validateReportV2ContextAjv = ajv.getSchema('/test-reporting/schemas/report/v2/context/loose.json');
 const validateReportV1Ajv = ajv.getSchema('/test-reporting/schemas/report/v1.json');
 const validateReportV2Ajv = ajv.getSchema('/test-reporting/schemas/report/v2.json');
+const formatErrorAjv = ajv.errorsText;
 const { properties: latestReportSchemaProperties } = latestReportSchema;
 const { version: { const: latestReportVersion } } = latestReportSchemaProperties;
 const { details: { items: { properties: { browser: { enum: latestSupportedBrowsers } } } } } = latestReportSchemaProperties;
-
-const formatErrorAjv = (dataVar, errors) => {
-	const { instancePath, message: ajvMessage, parentSchema: { type }, data } = errors[0];
-	const formattedData = JSON.stringify(data, null, 2);
-	const sanitizedInstancePath = instancePath === '' ? '/' : instancePath;
-	const errorMessageParts = [
-		`${dataVar} does not conform to schema`,
-		`Details: the ${type} at '${sanitizedInstancePath}' ${ajvMessage}`
-	];
-
-	if (formattedData.includes('\n')) {
-		errorMessageParts.push(`Current value:\n\n${formattedData}\n`);
-	} else {
-		errorMessageParts.push(`Current value: ${formattedData}`);
-	}
-
-	return errorMessageParts.join('\n');
-};
 
 module.exports = {
 	formatErrorAjv,


### PR DESCRIPTION
Switch to use [`ajv-errors`](https://www.npmjs.com/package/ajv-errors) instead of rolling our own error message handling. This adds simple messages to the weird pattern ones to give more context. We can add more messaging as we find we need it.

https://desire2learn.atlassian.net/browse/QE-581