### PR TITLE
Disallow promise chaining

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ import { includeIgnoreFile } from '@eslint/compat';
 import jsonPlugin from 'eslint-plugin-json';
 import mochaPlugin from 'eslint-plugin-mocha';
 import playwrightPlugin from 'eslint-plugin-playwright';
+import promisePlugin from 'eslint-plugin-promise';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -28,16 +29,25 @@ const importConfigs = [
 		}
 	}
 ];
-const commandDangleConfig = {
-	rules: {
-		'comma-dangle': 'error'
+const commonConfigs = [
+	{
+		rules: {
+			'comma-dangle': 'error',
+			'require-await': 'error'
+		}
+	},
+	promisePlugin.configs['flat/recommended'],
+	{
+		rules: {
+			'promise/prefer-await-to-then': ['error', { strict: true }]
+		}
 	}
-};
+];
 const globalConfigs = addExtensions(
 	[
 		...nodeConfig,
 		...importConfigs,
-		commandDangleConfig
+		...commonConfigs
 	],
 	fileExtensions
 );
@@ -72,7 +82,7 @@ const mochaConfigs = addExtensions(
 const webTestRunnerConfigs = addExtensions(
 	[
 		...testingConfig,
-		commandDangleConfig
+		...commonConfigs
 	],
 	fileExtensions
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "eslint-plugin-json": "^4",
         "eslint-plugin-mocha": "^10",
         "eslint-plugin-playwright": "^2",
+        "eslint-plugin-promise": "^7",
         "npm-run-all": "^4",
         "playwright": "^1.49",
         "sinon": "^19"
@@ -4233,6 +4234,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-promise": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-7.2.1.tgz",
+      "integrity": "sha512-SWKjd+EuvWkYaS+uN2csvj0KoP43YTu7+phKQ5v+xw6+A0gutVX2yqCeCkC3uLCJFiPfR2dD8Es5L7yUsmvEaA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-react": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "eslint-plugin-json": "^4",
     "eslint-plugin-mocha": "^10",
     "eslint-plugin-playwright": "^2",
+    "eslint-plugin-promise": "^7",
     "npm-run-all": "^4",
     "playwright": "^1.49",
     "sinon": "^19"


### PR DESCRIPTION
Stops the mixing of `then`/`async`/`await` and just fully disallows `then` chaining. Forces more "modern" syntax.

https://desire2learn.atlassian.net/browse/QE-634