### PR TITLE
Add code owner data to generated reports

### DIFF
--- a/docs/report-format.md
+++ b/docs/report-format.md
@@ -56,6 +56,7 @@ stored in [AWS Timestream], please see [Storage Schema].
       },
       "name": "<Non-empty string matching pattern '^(?!\\s).+(?<!\\s)$>'",
       "status": "<Must be 'passed', 'skipped' or 'failed'>",
+      "codeowners": "<Array of non-empty strings from CODEOWNERS file, optional>",
       "retries": "<Positive integer, can be 0>",
       "timeout": "<Positive integer representing milliseconds, can be 0, optional>",
       "browser": "<Can be 'chromium', 'chrome', 'firefox', 'webkit', 'safari' or 'edge', optional>",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "ajv-errors": "^3",
         "ajv-formats": "^3",
         "chalk": "^5",
+        "codeowners": "^5",
         "lodash": "^4",
         "minimatch": "^10",
         "mocha": "^11",
@@ -5110,6 +5111,99 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/codeowners": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/codeowners/-/codeowners-5.1.1.tgz",
+      "integrity": "sha512-NKsnAQQBhdsfkm7xZb073MTlzfz9kmE9iyjIcsfU9kZMPq2E7e+O42HD+yFTIu3f1CwvnBsSFdSLjv5k6CRIZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.walk": "^1.2.6",
+        "commander": "^6.2.1",
+        "find-up": "^2.1.0",
+        "ignore": "^3.3.10",
+        "is-directory": "^0.3.1",
+        "lodash.intersection": "^4.4.0",
+        "lodash.maxby": "^4.6.0",
+        "lodash.padend": "^4.6.1",
+        "true-case-path": "^1.0.3"
+      },
+      "bin": {
+        "codeowners": "index.js"
+      }
+    },
+    "node_modules/codeowners/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/codeowners/node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/codeowners/node_modules/ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "license": "MIT"
+    },
+    "node_modules/codeowners/node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/codeowners/node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/codeowners/node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/codeowners/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -5210,7 +5304,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/content-disposition": {
@@ -7823,7 +7916,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -8527,7 +8619,6 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -8781,6 +8872,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-docker": {
@@ -10203,11 +10303,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.intersection": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.intersection/-/lodash.intersection-4.4.0.tgz",
+      "integrity": "sha512-N+L0cCfnqMv6mxXtSPeKt+IavbOBBSiAEkKyLasZ8BVcP9YXQgxLO12oPR8OyURwKV8l5vJKiE1M8aS70heuMg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.maxby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.maxby/-/lodash.maxby-4.6.0.tgz",
+      "integrity": "sha512-QfTqQTwzmKxLy7VZlbx2M/ipWv8DCQ2F5BI/MRxLharOQ5V78yMSuB+JE+EuUM22txYfj09R2Q7hUlEYj7KdNg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.padend": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "integrity": "sha512-sOQs2aqGpbl27tmCS1QNZA09Uqp01ZzWfDUoD+xzTii0E7dSQfRKcRetFwa+uXaxaqL+TKm7CgD2JdKP7aZBSw==",
       "license": "MIT"
     },
     "node_modules/lodash.pickby": {
@@ -11153,7 +11271,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -11328,6 +11445,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/pac-proxy-agent": {
@@ -13943,6 +14069,64 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/true-case-path": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
+      "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "glob": "^7.1.2"
+      }
+    },
+    "node_modules/true-case-path/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/true-case-path/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/true-case-path/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/true-case-path/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -14927,7 +15111,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "ajv-errors": "^3",
     "ajv-formats": "^3",
     "chalk": "^5",
+    "codeowners": "^5",
     "lodash": "^4",
     "minimatch": "^10",
     "mocha": "^11",

--- a/schemas/report/v2.json
+++ b/schemas/report/v2.json
@@ -190,6 +190,13 @@
           "retries": {
             "type": "integer",
             "minimum": 0
+          },
+          "codeowners": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/codeownerString"
+            },
+            "minItems": 1
           }
         },
         "required": [
@@ -219,6 +226,21 @@
       "errorMessage": {
         "pattern": "should be non-empty without leading or trailing whitespace"
       }
+    },
+    "codeownerString": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/nonEmptyUnpaddedString"
+        },
+        {
+          "type": "string",
+          "pattern": "^@\\S+$",
+          "minLength": 2,
+          "errorMessage": {
+            "pattern": "should be a valid codeowner starting with @ and containing no whitespace"
+          }
+        }
+      ]
     },
     "context": {
       "$schema": "https://json-schema.org/draft/2019-09/schema",

--- a/src/helpers/report-builder.cjs
+++ b/src/helpers/report-builder.cjs
@@ -1,3 +1,4 @@
+const Codeowners = require('codeowners');
 const { getContext, hasContext } = require('./github.cjs');
 const { getOperatingSystemType, makeRelativeFilePath } = require('./system.cjs');
 const { randomUUID } = require('node:crypto');
@@ -23,6 +24,7 @@ const reportMemberPriority = [
 	'sha',
 	'name',
 	'status',
+	'codeowners',
 	'lms',
 	'buildNumber',
 	'instanceUrl',
@@ -172,10 +174,11 @@ class ReportSummaryBuilder extends ReportBuilderBase {
 }
 
 class ReportDetailBuilder extends ReportBuilderBase {
-	constructor(reportConfiguration) {
+	constructor(reportConfiguration, codeowners) {
 		super();
 
 		this._reportConfiguration = reportConfiguration;
+		this._codeowners = codeowners;
 
 		this._setProperty('retries', 0);
 	}
@@ -197,15 +200,21 @@ class ReportDetailBuilder extends ReportBuilderBase {
 
 		this._setNestedProperty('location', 'file', filePath, options);
 
-		if (!this._reportConfiguration) {
-			return this;
+		if (this._reportConfiguration) {
+			const { type, tool, experience } = this._reportConfiguration.getTaxonomy(filePath);
+
+			this._setProperty('type', type, options);
+			this._setProperty('tool', tool, options);
+			this._setProperty('experience', experience, options);
 		}
 
-		const { type, tool, experience } = this._reportConfiguration.getTaxonomy(filePath);
+		if (this._codeowners) {
+			const owners = this._codeowners.getOwner(filePath);
 
-		this._setProperty('type', type, options);
-		this._setProperty('tool', tool, options);
-		this._setProperty('experience', experience, options);
+			if (owners.length > 0) {
+				this._setProperty('codeowners', owners, options);
+			}
+		}
 
 		return this;
 	}
@@ -298,6 +307,12 @@ class ReportBuilder extends ReportBuilderBase {
 		this._verbose = verbose;
 		this._reportConfiguration = new ReportConfiguration(reportConfigurationPath);
 
+		try {
+			this._codeowners = new Codeowners();
+		} catch {
+			this._codeowners = null;
+		}
+
 		if (reportWriter) {
 			if (reportPath) {
 				throw new Error('must supply only one of \'reportPath\' or \'reportWriter\'');
@@ -340,7 +355,7 @@ class ReportBuilder extends ReportBuilderBase {
 		const { details } = this._data;
 
 		if (!details.has(id)) {
-			details.set(id, new ReportDetailBuilder(this._reportConfiguration));
+			details.set(id, new ReportDetailBuilder(this._reportConfiguration, this._codeowners));
 		}
 
 		return details.get(id);

--- a/src/helpers/report.cjs
+++ b/src/helpers/report.cjs
@@ -1,9 +1,28 @@
+const Codeowners = require('codeowners');
 const schema = require('./schema.cjs');
 const { flatten } = require('./object.cjs');
 const fs = require('node:fs');
 const { makeRelativeFilePath } = require('./system.cjs');
 const { omit } = require('lodash');
 const { resolve } = require('node:path');
+
+const isCurrentRepository = (organization, repository) => {
+	const { env: { GITHUB_REPOSITORY } } = process;
+
+	if (!GITHUB_REPOSITORY) {
+		return false;
+	}
+
+	return GITHUB_REPOSITORY === `${organization}/${repository}`;
+};
+
+const getCodeowners = () => {
+	try {
+		return new Codeowners();
+	} catch {
+		return null;
+	}
+};
 
 const {
 	formatErrorAjv,
@@ -247,6 +266,10 @@ const upgradeReportV1ToV2 = (report) => {
 		summaryUpgraded.lms.instanceUrl = lmsInstanceUrl;
 	}
 
+	const codeowners = isCurrentRepository(githubOrganization, githubRepository) ?
+		getCodeowners() :
+		null;
+
 	return {
 		id: reportId,
 		version: 2,
@@ -254,8 +277,7 @@ const upgradeReportV1ToV2 = (report) => {
 		details: details.map((detail) => {
 			const { location, duration, totalDuration } = detail;
 			const detailCommon = omit(detail, ['totalDuration']);
-
-			return {
+			const upgraded = {
 				...detailCommon,
 				location: {
 					file: location
@@ -265,6 +287,16 @@ const upgradeReportV1ToV2 = (report) => {
 					final: duration
 				}
 			};
+
+			if (codeowners) {
+				const owners = codeowners.getOwner(location);
+
+				if (owners.length > 0) {
+					upgraded.codeowners = owners;
+				}
+			}
+
+			return upgraded;
 		})
 	};
 };

--- a/test/integration/data/validation/test-report-mocha.js
+++ b/test/integration/data/validation/test-report-mocha.js
@@ -8,6 +8,7 @@ export const testReportV2Partial = {
 	details: [{
 		name: 'reporter 1 > passed',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/mocha/reporter-1.test.js' },
 		timeout: 2000,
 		tool: 'Mocha 1 Test Reporting',
@@ -17,6 +18,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 1 > skipped',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/mocha/reporter-1.test.js' },
 		timeout: 2000,
 		tool: 'Mocha 1 Test Reporting',
@@ -26,6 +28,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 1 > flaky',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/mocha/reporter-1.test.js' },
 		timeout: 2000,
 		tool: 'Mocha 1 Test Reporting',
@@ -35,6 +38,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 1 > failed',
 		status: 'failed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/mocha/reporter-1.test.js' },
 		timeout: 2000,
 		tool: 'Mocha 1 Test Reporting',
@@ -44,6 +48,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 2 > passed',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/mocha/reporter-2.test.js' },
 		timeout: 2000,
 		tool: 'Test Reporting',
@@ -53,6 +58,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 2 > skipped',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/mocha/reporter-2.test.js' },
 		timeout: 2000,
 		tool: 'Test Reporting',
@@ -62,6 +68,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 2 > flaky',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/mocha/reporter-2.test.js' },
 		timeout: 2000,
 		tool: 'Test Reporting',
@@ -71,6 +78,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 2 > failed',
 		status: 'failed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/mocha/reporter-2.test.js' },
 		timeout: 2000,
 		tool: 'Test Reporting',
@@ -80,6 +88,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 1 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/mocha/reporter-1.test.js' },
 		timeout: 2000,
 		tool: 'Mocha 1 Test Reporting',
@@ -89,6 +98,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 2 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/mocha/reporter-2.test.js' },
 		timeout: 2000,
 		tool: 'Test Reporting',

--- a/test/integration/data/validation/test-report-playwright.js
+++ b/test/integration/data/validation/test-report-playwright.js
@@ -8,6 +8,7 @@ export const testReportV2Partial = {
 	details: [{
 		name: '[chromium] > reporter 1 > skipped static, fixme',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 20,
@@ -22,6 +23,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > skipped static, fixme',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 20,
@@ -36,6 +38,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > passed',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 16,
@@ -50,6 +53,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > skipped dynamic, fixme',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 26,
@@ -64,6 +68,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > failed dynamic expected',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 44,
@@ -78,6 +83,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > skipped static',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 18,
@@ -92,6 +98,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > passed',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 16,
@@ -106,6 +113,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > failed',
 		status: 'failed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 40,
@@ -120,6 +128,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > skipped dynamic',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 22,
@@ -134,6 +143,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > failed static expected, skipped dynamic, fixme',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 56,
@@ -148,6 +158,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > skipped dynamic',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 22,
@@ -162,6 +173,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > skipped static',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 18,
@@ -176,6 +188,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > flaky',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 30,
@@ -190,6 +203,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > failed static expected, skipped dynamic',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 50,
@@ -204,6 +218,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > skipped dynamic, fixme',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 26,
@@ -218,6 +233,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > failed dynamic expected',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 44,
@@ -232,6 +248,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > failed',
 		status: 'failed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 40,
@@ -246,6 +263,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > failed static expected, skipped dynamic, fixme',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 56,
@@ -260,6 +278,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > flaky',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 30,
@@ -274,6 +293,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > failed static expected, skipped dynamic',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 50,
@@ -288,6 +308,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > skipped static, fixme',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 20,
@@ -302,6 +323,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > passed',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 16,
@@ -316,6 +338,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > skipped static',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 18,
@@ -330,6 +353,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > skipped dynamic',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 22,
@@ -344,6 +368,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > skipped dynamic, fixme',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 26,
@@ -358,6 +383,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > failed dynamic expected',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 44,
@@ -372,6 +398,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > flaky',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 30,
@@ -386,6 +413,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > failed static expected, skipped dynamic',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 50,
@@ -400,6 +428,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > failed',
 		status: 'failed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 40,
@@ -414,6 +443,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > failed static expected, skipped dynamic, fixme',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 56,
@@ -428,6 +458,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > skipped static, fixme',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 20,
@@ -442,6 +473,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > passed',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 16,
@@ -456,6 +488,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > skipped static',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 18,
@@ -470,6 +503,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > failed static expected',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 42,
@@ -484,6 +518,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > skipped dynamic',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 22,
@@ -498,6 +533,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > failed',
 		status: 'failed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 40,
@@ -512,6 +548,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > failed static expected',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 42,
@@ -526,6 +563,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > skipped dynamic, fixme',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 26,
@@ -540,6 +578,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > failed static expected, skipped dynamic, fixme',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 56,
@@ -554,6 +593,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > skipped static, fixme',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 20,
@@ -568,6 +608,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > failed dynamic expected',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 44,
@@ -582,6 +623,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > flaky',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 30,
@@ -596,6 +638,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > skipped dynamic',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 22,
@@ -610,6 +653,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > failed static expected, skipped dynamic',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 50,
@@ -624,6 +668,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > passed',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 16,
@@ -638,6 +683,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > failed dynamic expected',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 44,
@@ -652,6 +698,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > skipped static',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 18,
@@ -666,6 +713,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > failed static expected, skipped dynamic, fixme',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 56,
@@ -680,6 +728,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > failed static expected, skipped dynamic',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 50,
@@ -694,6 +743,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > skipped dynamic, fixme',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 26,
@@ -708,6 +758,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > failed',
 		status: 'failed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 40,
@@ -722,6 +773,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > flaky',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 30,
@@ -736,6 +788,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > failed static expected',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 42,
@@ -750,6 +803,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > failed static expected',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 42,
@@ -764,6 +818,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > failed static expected',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 42,
@@ -778,6 +833,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 62,
@@ -792,6 +848,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 62,
@@ -806,6 +863,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 62,
@@ -820,6 +878,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 62,
@@ -834,6 +893,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 62,

--- a/test/integration/data/validation/test-report-web-test-runner.js
+++ b/test/integration/data/validation/test-report-web-test-runner.js
@@ -8,6 +8,7 @@ export const testReportV2Partial = {
 	details: [{
 		name: 'reporter 1 > passed',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'chrome',
 		timeout: 120000,
@@ -18,6 +19,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 1 > skipped',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'chrome',
 		timeout: 120000,
@@ -28,6 +30,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 1 > failed',
 		status: 'failed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'chrome',
 		timeout: 120000,
@@ -38,6 +41,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 1] > reporter 2 > passed',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'chromium',
 		timeout: 120000,
@@ -48,6 +52,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 1] > reporter 2 > skipped',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'chromium',
 		timeout: 120000,
@@ -58,6 +63,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 1] > reporter 2 > failed',
 		status: 'failed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'chromium',
 		timeout: 120000,
@@ -68,6 +74,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 1] > reporter 2 > passed',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'firefox',
 		timeout: 120000,
@@ -78,6 +85,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 1] > reporter 2 > skipped',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'firefox',
 		timeout: 120000,
@@ -88,6 +96,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 1] > reporter 2 > failed',
 		status: 'failed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'firefox',
 		timeout: 120000,
@@ -98,6 +107,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 2] > reporter 1 > passed',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'webkit',
 		timeout: 120000,
@@ -108,6 +118,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 2] > reporter 1 > skipped',
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'webkit',
 		timeout: 120000,
@@ -118,6 +129,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 2] > reporter 1 > failed',
 		status: 'failed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'webkit',
 		timeout: 120000,
@@ -128,6 +140,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 1 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'chrome',
 		timeout: 120000,
@@ -138,6 +151,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 1] > reporter 2 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'chromium',
 		timeout: 120000,
@@ -148,6 +162,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 1] > reporter 2 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'firefox',
 		timeout: 120000,
@@ -158,6 +173,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 2] > reporter 1 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'webkit',
 		timeout: 120000,

--- a/test/integration/data/validation/test-report-webdriverio.js
+++ b/test/integration/data/validation/test-report-webdriverio.js
@@ -12,6 +12,7 @@ export const testReportV2Partial = {
 	details: [{
 		name: `[${platform}] > reporter 1 > passed`,
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-1.test.js' },
 		tool: 'WebdriverIO 1 Test Reporting',
 		experience: 'Test Framework',
@@ -20,6 +21,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 1 > skipped`,
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-1.test.js' },
 		tool: 'WebdriverIO 1 Test Reporting',
 		experience: 'Test Framework',
@@ -28,6 +30,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 1 > flaky`,
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-1.test.js' },
 		tool: 'WebdriverIO 1 Test Reporting',
 		experience: 'Test Framework',
@@ -36,6 +39,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 1 > failed`,
 		status: 'failed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-1.test.js' },
 		tool: 'WebdriverIO 1 Test Reporting',
 		experience: 'Test Framework',
@@ -44,6 +48,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 1 > special/characters "(\\n\\r\\t\\b\\f)"`,
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-1.test.js' },
 		tool: 'WebdriverIO 1 Test Reporting',
 		experience: 'Test Framework',
@@ -52,6 +57,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 2 > passed`,
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-2.test.js' },
 		tool: 'Test Reporting',
 		experience: 'WebdriverIO 2 Test Framework',
@@ -60,6 +66,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 2 > skipped`,
 		status: 'skipped',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-2.test.js' },
 		tool: 'Test Reporting',
 		experience: 'WebdriverIO 2 Test Framework',
@@ -68,6 +75,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 2 > flaky`,
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-2.test.js' },
 		tool: 'Test Reporting',
 		experience: 'WebdriverIO 2 Test Framework',
@@ -76,6 +84,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 2 > special/characters "(\\n\\r\\t\\b\\f)"`,
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-2.test.js' },
 		tool: 'Test Reporting',
 		experience: 'WebdriverIO 2 Test Framework',
@@ -84,6 +93,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 2 > passed 2`,
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-2.test.js' },
 		tool: 'Test Reporting',
 		experience: 'WebdriverIO 2 Test Framework',
@@ -92,6 +102,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 2 > passed 3`,
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-2.test.js' },
 		tool: 'Test Reporting',
 		experience: 'WebdriverIO 2 Test Framework',
@@ -100,6 +111,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 2 > passed 4`,
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-2.test.js' },
 		tool: 'Test Reporting',
 		experience: 'WebdriverIO 2 Test Framework',
@@ -108,6 +120,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 2 > passed with timeout`,
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-2.test.js' },
 		tool: 'Test Reporting',
 		experience: 'WebdriverIO 2 Test Framework',
@@ -116,6 +129,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 3 > passed 1`,
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-3.test.js' },
 		tool: 'Test Reporting',
 		experience: 'Test Framework',
@@ -124,6 +138,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 3 > passed 2`,
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-3.test.js' },
 		tool: 'Test Reporting',
 		experience: 'Test Framework',
@@ -132,6 +147,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 3 > passed 3`,
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-3.test.js' },
 		tool: 'Test Reporting',
 		experience: 'Test Framework',
@@ -140,6 +156,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 3 > passed 4`,
 		status: 'passed',
+		codeowners: ['@Brightspace/quality-enablement'],
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-3.test.js' },
 		tool: 'Test Reporting',
 		experience: 'Test Framework',


### PR DESCRIPTION
This adds a new `codeowners` property to each test detail run that will include data in an array from the `CODEOWNERS` file in the repo it is generated from. I chose to add this as an field to the existing `v2` schema as it's non-destructive and optional. We may have to make changes to account for if we generate a report in another repo from where we submit it but we can handle that later as we don't have any scenarios right now I could find of that happening. Possibly aq problem with [Brightspace/test-actions/run-playwright-ui](https://github.com/Brightspace/test-actions/tree/main/run-playwright-ui) but we can figure that out separately.

https://desire2learn.atlassian.net/browse/QE-651