### PR TITLE
Adjust codeowners

### DIFF
--- a/docs/report-format.md
+++ b/docs/report-format.md
@@ -56,7 +56,9 @@ stored in [AWS Timestream], please see [Storage Schema].
       },
       "name": "<Non-empty string matching pattern '^(?!\\s).+(?<!\\s)$>'",
       "status": "<Must be 'passed', 'skipped' or 'failed'>",
-      "codeowners": "<Array of non-empty strings from CODEOWNERS file, optional>",
+      "github": {
+        "codeowners": "<Array of non-empty strings starting with @ from CODEOWNERS file, optional>"
+      },
       "retries": "<Positive integer, can be 0>",
       "timeout": "<Positive integer representing milliseconds, can be 0, optional>",
       "browser": "<Can be 'chromium', 'chrome', 'firefox', 'webkit', 'safari' or 'edge', optional>",

--- a/schemas/report/v2.json
+++ b/schemas/report/v2.json
@@ -191,12 +191,17 @@
             "type": "integer",
             "minimum": 0
           },
-          "codeowners": {
-            "type": "array",
-            "items": {
-              "$ref": "#/$defs/codeownerString"
-            },
-            "minItems": 1
+          "github": {
+            "type": "object",
+            "properties": {
+              "codeowners": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/$defs/githubCodeownerString"
+                },
+                "minItems": 1
+              }
+            }
           }
         },
         "required": [
@@ -227,7 +232,7 @@
         "pattern": "should be non-empty without leading or trailing whitespace"
       }
     },
-    "codeownerString": {
+    "githubCodeownerString": {
       "allOf": [
         {
           "$ref": "#/$defs/nonEmptyUnpaddedString"

--- a/src/helpers/report-builder.cjs
+++ b/src/helpers/report-builder.cjs
@@ -212,7 +212,7 @@ class ReportDetailBuilder extends ReportBuilderBase {
 			const owners = this._codeowners.getOwner(filePath);
 
 			if (owners.length > 0) {
-				this._setProperty('codeowners', owners, options);
+				this._setNestedProperty('github', 'codeowners', owners, options);
 			}
 		}
 

--- a/src/helpers/report.cjs
+++ b/src/helpers/report.cjs
@@ -292,7 +292,7 @@ const upgradeReportV1ToV2 = (report) => {
 				const owners = codeowners.getOwner(location);
 
 				if (owners.length > 0) {
-					upgraded.codeowners = owners;
+					upgraded.github = { codeowners: owners };
 				}
 			}
 

--- a/test/integration/data/validation/test-report-mocha.js
+++ b/test/integration/data/validation/test-report-mocha.js
@@ -8,7 +8,7 @@ export const testReportV2Partial = {
 	details: [{
 		name: 'reporter 1 > passed',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/mocha/reporter-1.test.js' },
 		timeout: 2000,
 		tool: 'Mocha 1 Test Reporting',
@@ -18,7 +18,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 1 > skipped',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/mocha/reporter-1.test.js' },
 		timeout: 2000,
 		tool: 'Mocha 1 Test Reporting',
@@ -28,7 +28,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 1 > flaky',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/mocha/reporter-1.test.js' },
 		timeout: 2000,
 		tool: 'Mocha 1 Test Reporting',
@@ -38,7 +38,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 1 > failed',
 		status: 'failed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/mocha/reporter-1.test.js' },
 		timeout: 2000,
 		tool: 'Mocha 1 Test Reporting',
@@ -48,7 +48,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 2 > passed',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/mocha/reporter-2.test.js' },
 		timeout: 2000,
 		tool: 'Test Reporting',
@@ -58,7 +58,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 2 > skipped',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/mocha/reporter-2.test.js' },
 		timeout: 2000,
 		tool: 'Test Reporting',
@@ -68,7 +68,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 2 > flaky',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/mocha/reporter-2.test.js' },
 		timeout: 2000,
 		tool: 'Test Reporting',
@@ -78,7 +78,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 2 > failed',
 		status: 'failed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/mocha/reporter-2.test.js' },
 		timeout: 2000,
 		tool: 'Test Reporting',
@@ -88,7 +88,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 1 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/mocha/reporter-1.test.js' },
 		timeout: 2000,
 		tool: 'Mocha 1 Test Reporting',
@@ -98,7 +98,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 2 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/mocha/reporter-2.test.js' },
 		timeout: 2000,
 		tool: 'Test Reporting',

--- a/test/integration/data/validation/test-report-playwright.js
+++ b/test/integration/data/validation/test-report-playwright.js
@@ -8,7 +8,7 @@ export const testReportV2Partial = {
 	details: [{
 		name: '[chromium] > reporter 1 > skipped static, fixme',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 20,
@@ -23,7 +23,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > skipped static, fixme',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 20,
@@ -38,7 +38,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > passed',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 16,
@@ -53,7 +53,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > skipped dynamic, fixme',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 26,
@@ -68,7 +68,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > failed dynamic expected',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 44,
@@ -83,7 +83,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > skipped static',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 18,
@@ -98,7 +98,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > passed',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 16,
@@ -113,7 +113,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > failed',
 		status: 'failed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 40,
@@ -128,7 +128,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > skipped dynamic',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 22,
@@ -143,7 +143,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > failed static expected, skipped dynamic, fixme',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 56,
@@ -158,7 +158,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > skipped dynamic',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 22,
@@ -173,7 +173,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > skipped static',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 18,
@@ -188,7 +188,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > flaky',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 30,
@@ -203,7 +203,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > failed static expected, skipped dynamic',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 50,
@@ -218,7 +218,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > skipped dynamic, fixme',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 26,
@@ -233,7 +233,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > failed dynamic expected',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 44,
@@ -248,7 +248,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > failed',
 		status: 'failed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 40,
@@ -263,7 +263,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > failed static expected, skipped dynamic, fixme',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 56,
@@ -278,7 +278,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > flaky',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 30,
@@ -293,7 +293,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > failed static expected, skipped dynamic',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 50,
@@ -308,7 +308,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > skipped static, fixme',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 20,
@@ -323,7 +323,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > passed',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 16,
@@ -338,7 +338,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > skipped static',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 18,
@@ -353,7 +353,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > skipped dynamic',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 22,
@@ -368,7 +368,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > skipped dynamic, fixme',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 26,
@@ -383,7 +383,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > failed dynamic expected',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 44,
@@ -398,7 +398,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > flaky',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 30,
@@ -413,7 +413,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > failed static expected, skipped dynamic',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 50,
@@ -428,7 +428,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > failed',
 		status: 'failed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 40,
@@ -443,7 +443,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > failed static expected, skipped dynamic, fixme',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 56,
@@ -458,7 +458,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > skipped static, fixme',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 20,
@@ -473,7 +473,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > passed',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 16,
@@ -488,7 +488,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > skipped static',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 18,
@@ -503,7 +503,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > failed static expected',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 42,
@@ -518,7 +518,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > skipped dynamic',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 22,
@@ -533,7 +533,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > failed',
 		status: 'failed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 40,
@@ -548,7 +548,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > failed static expected',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 42,
@@ -563,7 +563,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > skipped dynamic, fixme',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 26,
@@ -578,7 +578,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > failed static expected, skipped dynamic, fixme',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 56,
@@ -593,7 +593,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > skipped static, fixme',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 20,
@@ -608,7 +608,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > failed dynamic expected',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 44,
@@ -623,7 +623,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > flaky',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 30,
@@ -638,7 +638,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > skipped dynamic',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 22,
@@ -653,7 +653,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > failed static expected, skipped dynamic',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 50,
@@ -668,7 +668,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > passed',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 16,
@@ -683,7 +683,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > failed dynamic expected',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 44,
@@ -698,7 +698,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > skipped static',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 18,
@@ -713,7 +713,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > failed static expected, skipped dynamic, fixme',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 56,
@@ -728,7 +728,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > failed static expected, skipped dynamic',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 50,
@@ -743,7 +743,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > skipped dynamic, fixme',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 26,
@@ -758,7 +758,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > failed',
 		status: 'failed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 40,
@@ -773,7 +773,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > flaky',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 30,
@@ -788,7 +788,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > failed static expected',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 42,
@@ -803,7 +803,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > failed static expected',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 42,
@@ -818,7 +818,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > failed static expected',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 42,
@@ -833,7 +833,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 1 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 62,
@@ -848,7 +848,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[chromium] > reporter 2 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 62,
@@ -863,7 +863,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[firefox] > reporter 2 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 62,
@@ -878,7 +878,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 1 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-1.test.js',
 			line: 62,
@@ -893,7 +893,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[webkit] > reporter 2 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: {
 			file: 'test/integration/data/tests/playwright/reporter-2.test.js',
 			line: 62,

--- a/test/integration/data/validation/test-report-web-test-runner.js
+++ b/test/integration/data/validation/test-report-web-test-runner.js
@@ -8,7 +8,7 @@ export const testReportV2Partial = {
 	details: [{
 		name: 'reporter 1 > passed',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'chrome',
 		timeout: 120000,
@@ -19,7 +19,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 1 > skipped',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'chrome',
 		timeout: 120000,
@@ -30,7 +30,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 1 > failed',
 		status: 'failed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'chrome',
 		timeout: 120000,
@@ -41,7 +41,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 1] > reporter 2 > passed',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'chromium',
 		timeout: 120000,
@@ -52,7 +52,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 1] > reporter 2 > skipped',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'chromium',
 		timeout: 120000,
@@ -63,7 +63,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 1] > reporter 2 > failed',
 		status: 'failed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'chromium',
 		timeout: 120000,
@@ -74,7 +74,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 1] > reporter 2 > passed',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'firefox',
 		timeout: 120000,
@@ -85,7 +85,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 1] > reporter 2 > skipped',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'firefox',
 		timeout: 120000,
@@ -96,7 +96,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 1] > reporter 2 > failed',
 		status: 'failed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'firefox',
 		timeout: 120000,
@@ -107,7 +107,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 2] > reporter 1 > passed',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'webkit',
 		timeout: 120000,
@@ -118,7 +118,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 2] > reporter 1 > skipped',
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'webkit',
 		timeout: 120000,
@@ -129,7 +129,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 2] > reporter 1 > failed',
 		status: 'failed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'webkit',
 		timeout: 120000,
@@ -140,7 +140,7 @@ export const testReportV2Partial = {
 	}, {
 		name: 'reporter 1 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'chrome',
 		timeout: 120000,
@@ -151,7 +151,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 1] > reporter 2 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'chromium',
 		timeout: 120000,
@@ -162,7 +162,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 1] > reporter 2 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'firefox',
 		timeout: 120000,
@@ -173,7 +173,7 @@ export const testReportV2Partial = {
 	}, {
 		name: '[group 2] > reporter 1 > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'webkit',
 		timeout: 120000,

--- a/test/integration/data/validation/test-report-webdriverio.js
+++ b/test/integration/data/validation/test-report-webdriverio.js
@@ -12,7 +12,7 @@ export const testReportV2Partial = {
 	details: [{
 		name: `[${platform}] > reporter 1 > passed`,
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-1.test.js' },
 		tool: 'WebdriverIO 1 Test Reporting',
 		experience: 'Test Framework',
@@ -21,7 +21,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 1 > skipped`,
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-1.test.js' },
 		tool: 'WebdriverIO 1 Test Reporting',
 		experience: 'Test Framework',
@@ -30,7 +30,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 1 > flaky`,
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-1.test.js' },
 		tool: 'WebdriverIO 1 Test Reporting',
 		experience: 'Test Framework',
@@ -39,7 +39,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 1 > failed`,
 		status: 'failed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-1.test.js' },
 		tool: 'WebdriverIO 1 Test Reporting',
 		experience: 'Test Framework',
@@ -48,7 +48,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 1 > special/characters "(\\n\\r\\t\\b\\f)"`,
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-1.test.js' },
 		tool: 'WebdriverIO 1 Test Reporting',
 		experience: 'Test Framework',
@@ -57,7 +57,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 2 > passed`,
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-2.test.js' },
 		tool: 'Test Reporting',
 		experience: 'WebdriverIO 2 Test Framework',
@@ -66,7 +66,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 2 > skipped`,
 		status: 'skipped',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-2.test.js' },
 		tool: 'Test Reporting',
 		experience: 'WebdriverIO 2 Test Framework',
@@ -75,7 +75,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 2 > flaky`,
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-2.test.js' },
 		tool: 'Test Reporting',
 		experience: 'WebdriverIO 2 Test Framework',
@@ -84,7 +84,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 2 > special/characters "(\\n\\r\\t\\b\\f)"`,
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-2.test.js' },
 		tool: 'Test Reporting',
 		experience: 'WebdriverIO 2 Test Framework',
@@ -93,7 +93,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 2 > passed 2`,
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-2.test.js' },
 		tool: 'Test Reporting',
 		experience: 'WebdriverIO 2 Test Framework',
@@ -102,7 +102,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 2 > passed 3`,
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-2.test.js' },
 		tool: 'Test Reporting',
 		experience: 'WebdriverIO 2 Test Framework',
@@ -111,7 +111,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 2 > passed 4`,
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-2.test.js' },
 		tool: 'Test Reporting',
 		experience: 'WebdriverIO 2 Test Framework',
@@ -120,7 +120,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 2 > passed with timeout`,
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-2.test.js' },
 		tool: 'Test Reporting',
 		experience: 'WebdriverIO 2 Test Framework',
@@ -129,7 +129,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 3 > passed 1`,
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-3.test.js' },
 		tool: 'Test Reporting',
 		experience: 'Test Framework',
@@ -138,7 +138,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 3 > passed 2`,
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-3.test.js' },
 		tool: 'Test Reporting',
 		experience: 'Test Framework',
@@ -147,7 +147,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 3 > passed 3`,
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-3.test.js' },
 		tool: 'Test Reporting',
 		experience: 'Test Framework',
@@ -156,7 +156,7 @@ export const testReportV2Partial = {
 	}, {
 		name: `[${platform}] > reporter 3 > passed 4`,
 		status: 'passed',
-		codeowners: ['@Brightspace/quality-enablement'],
+		github: { codeowners: ['@Brightspace/quality-enablement'] },
 		location: { file: 'test/integration/data/tests/webdriverio/reporter-3.test.js' },
 		tool: 'Test Reporting',
 		experience: 'Test Framework',


### PR DESCRIPTION
Since the codeowners field is github specific it makes sense to put it under a `github` sub section. I'm not gonna mark this as a breaking change as no one is using this field yet.

https://desire2learn.atlassian.net/browse/QE-651