### PR TITLE
fix: capture final timeout in mocha reporter

### DIFF
--- a/src/reporters/mocha.cjs
+++ b/src/reporters/mocha.cjs
@@ -108,7 +108,7 @@ class TestReportingMochaReporter extends Spec {
 	}
 
 	_onTestEnd(test) {
-		const { file } = test;
+		const { file, _timeout } = test;
 
 		if (this._report.ignoreFilePath(file)) {
 			return;
@@ -117,7 +117,9 @@ class TestReportingMochaReporter extends Spec {
 		const { duration, state } = test;
 		const name = makeDetailName(test);
 		const id = makeDetailId(file, name);
-		const detail = this._report.getDetail(id);
+		const detail = this._report
+			.getDetail(id)
+			.setTimeout(_timeout, { override: true });
 
 		if (state === 'pending') {
 			detail

--- a/test/integration/data/tests/mocha/custom-timeout.test.js
+++ b/test/integration/data/tests/mocha/custom-timeout.test.js
@@ -1,0 +1,15 @@
+const delay = (ms = 50) => {
+	return new Promise(resolve => setTimeout(resolve, ms));
+};
+
+describe('custom timeout', function() {
+	this.timeout(5000); // eslint-disable-line no-invalid-this
+
+	it('suite level timeout', async() => { await delay(); });
+
+	it('test level timeout', async function() {
+		this.timeout(10000); // eslint-disable-line no-invalid-this
+
+		await delay();
+	});
+});

--- a/test/integration/data/validation/test-report-mocha.js
+++ b/test/integration/data/validation/test-report-mocha.js
@@ -5,9 +5,23 @@ export const testReportLatestPartial = {
 	summary: {
 		status: 'failed',
 		framework: 'mocha',
-		count: { passed: 8, failed: 6, skipped: 2, flaky: 2 }
+		count: { passed: 10, failed: 6, skipped: 2, flaky: 2 }
 	},
 	details: [{
+		name: 'custom timeout > suite level timeout',
+		status: 'passed',
+		location: { file: 'test/integration/data/tests/mocha/custom-timeout.test.js' },
+		config: { timeout: 5000 },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 0
+	}, {
+		name: 'custom timeout > test level timeout',
+		status: 'passed',
+		location: { file: 'test/integration/data/tests/mocha/custom-timeout.test.js' },
+		config: { timeout: 10000 },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 0
+	}, {
 		name: 'reporter 1 > passed',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/mocha/reporter-1.test.js' },


### PR DESCRIPTION
The mocha reporter previously captured `_timeout` only in `_onTestBegin`, before the test body executes. If a test calls `this.timeout()` to override the timeout at runtime, the reporter would record the old default value instead of the actual timeout used.

This adds `setTimeout(_timeout, { override: true })` in `_onTestEnd` so the reporter captures the final timeout value after the test body has had a chance to modify it. The `{ override: true }` flag bypasses the first-write-wins behavior of `_setProperty`.

Adds a `custom-timeout.test.js` integration test that verifies both suite-level (`this.timeout(5000)` on a describe block) and test-level (`this.timeout(10000)` inside a test body) timeout overrides are captured correctly.

https://desire2learn.atlassian.net/browse/QE-2092