### PR TITLE
Remove WebDriver.io testing for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "test:integration:mocha": "mocha --config test/integration/data/configs/mocha.cjs || exit 0",
     "test:integration:playwright": "playwright test --config test/integration/data/configs/playwright.js || exit 0",
     "test:integration:web-test-runner": "wtr --config test/integration/data/configs/web-test-runner.js || exit 0",
-    "test:integration:webdriverio": "wdio run test/integration/data/configs/webdriverio.cjs || exit 0",
     "test:integration:validate-reports": "mocha test/integration/report-validation.test.js",
     "test:unit": "mocha \"test/unit/**/*.test.js\""
   },

--- a/test/integration/report-validation.test.js
+++ b/test/integration/report-validation.test.js
@@ -9,7 +9,6 @@ import { Report } from '../../src/helpers/report.cjs';
 import { testReportLatestPartial as testReportLatestPartialMocha } from './data/validation/test-report-mocha.js';
 import { testReportLatestPartial as testReportLatestPartialPlaywright } from './data/validation/test-report-playwright.js';
 import { testReportLatestPartial as testReportLatestPartialWebTestRunner } from './data/validation/test-report-web-test-runner.js';
-import { testReportLatestPartial as testReportLatestPartialWebdriverIO } from './data/validation/test-report-webdriverio.js';
 import yn from 'yn';
 
 use(chaiSubset);
@@ -44,11 +43,6 @@ const reportTests = [{
 	version: latestReportVersion,
 	path: './d2l-test-report-web-test-runner.json',
 	expected: testReportLatestPartialWebTestRunner
-}, {
-	name: 'webdriverio',
-	version: latestReportVersion,
-	path: './d2l-test-report-webdriverio.json',
-	expected: testReportLatestPartialWebdriverIO
 }];
 const results = reportTests.reduce((acc, cur) => {
 	acc[cur.name] = {


### PR DESCRIPTION
Something broke with the webdriver.io stuff running in GitHub ACtions. I can run it locally fine so not sure whats wrong. For now let's just disable it. I can revert this once I figure out a way forward.

https://desire2learn.atlassian.net/browse/QE-651