### PR TITLE
Move integration config to test data directory

### DIFF
--- a/d2l-test-reporting.config.json
+++ b/d2l-test-reporting.config.json
@@ -1,57 +1,13 @@
 {
-  "type": "integration",
-  "experience": "Test Framework",
-  "tool": "Test Reporting",
-  "ignorePatterns": [
-    "**/tests/mocha/ignored.test.js",
-    "**/tests/playwright/reporter-3.test.js",
-    "**/tests/playwright/setup.js",
-    "**/tests/playwright/teardown.js",
-    "**/tests/web-test-runner/reporter-3.test.js"
-  ],
+  "tool": "Test Tooling",
   "overrides": [
     {
-      "pattern": "**/tests/mocha/statuses.test.js",
-      "type": "ui",
-      "tool": "Mocha 1 Test Reporting"
+      "pattern": "./test/unit/**",
+      "type": "unit"
     },
     {
-      "pattern": "**/tests/mocha/taxonomy-overrides.test.js",
-      "experience": "Mocha 2 Test Framework"
-    },
-    {
-      "pattern": "**/tests/mocha/hook-failures.test.js",
-      "type": "ui",
-      "tool": "Mocha Hook Failures Test Reporting"
-    },
-    {
-      "pattern": "**/tests/playwright/reporter-1.test.js",
-      "experience": "Playwright 1 Test Framework",
-      "tool": "Playwright 1 Test Reporting"
-    },
-    {
-      "pattern": "**/tests/playwright/reporter-2.test.js",
-      "type": "visual diff",
-      "experience": "Playwright 2 Test Framework"
-    },
-    {
-      "pattern": "**/tests/web-test-runner/reporter-1.test.js",
-      "experience": "WebTestRunner 1 Test Framework",
-      "tool": "WebTestRunner 1 Test Reporting"
-    },
-    {
-      "pattern": "**/tests/web-test-runner/reporter-2.test.js",
-      "type": "accessibility",
-      "experience": "WebTestRunner 2 Test Framework"
-    },
-    {
-      "pattern": "**/tests/webdriverio/reporter-1.test.js",
-      "type": "ui",
-      "tool": "WebdriverIO 1 Test Reporting"
-    },
-    {
-      "pattern": "**/tests/webdriverio/reporter-2.test.js",
-      "experience": "WebdriverIO 2 Test Framework"
+      "pattern": "./test/integration/**",
+      "type": "integration"
     }
   ]
 }

--- a/test/integration/data/configs/mocha.cjs
+++ b/test/integration/data/configs/mocha.cjs
@@ -4,6 +4,7 @@ module.exports = {
 	reporter: 'src/reporters/mocha.cjs',
 	reporterOptions: [
 		'reportPath=./d2l-test-report-mocha.json',
+		'reportConfigurationPath=./test/integration/data/d2l-test-reporting.config.json',
 		'reportVersionLatest=true',
 		'reportConfigurationVersionLatest=true',
 		'verbose=true'

--- a/test/integration/data/configs/playwright.js
+++ b/test/integration/data/configs/playwright.js
@@ -2,6 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 
 const playwrightReporterOptions = {
 	reportPath: './d2l-test-report-playwright.json',
+	reportConfigurationPath: './test/integration/data/d2l-test-reporting.config.json',
 	reportVersionLatest: true,
 	reportConfigurationVersionLatest: true,
 	verbose: true

--- a/test/integration/data/configs/web-test-runner.js
+++ b/test/integration/data/configs/web-test-runner.js
@@ -7,6 +7,7 @@ export default {
 		defaultReporter(),
 		reporter({
 			reportPath: './d2l-test-report-web-test-runner.json',
+			reportConfigurationPath: './test/integration/data/d2l-test-reporting.config.json',
 			reportVersionLatest: true,
 			reportConfigurationVersionLatest: true,
 			verbose: true

--- a/test/integration/data/configs/webdriverio.cjs
+++ b/test/integration/data/configs/webdriverio.cjs
@@ -24,7 +24,7 @@ exports.config = {
 		'spec',
 		[join(__dirname, '../../../../src/reporters/webdriverio.cjs'), {
 			reportPath: './d2l-test-report-webdriverio.json',
-			reportConfigurationPath: './d2l-test-reporting.config.json',
+			reportConfigurationPath: './test/integration/data/d2l-test-reporting.config.json',
 			reportVersionLatest: true,
 			reportConfigurationVersionLatest: true,
 			verbose: true

--- a/test/integration/data/d2l-test-reporting.config.json
+++ b/test/integration/data/d2l-test-reporting.config.json
@@ -1,0 +1,57 @@
+{
+  "type": "integration",
+  "experience": "Test Framework",
+  "tool": "Test Reporting",
+  "ignorePatterns": [
+    "**/tests/mocha/ignored.test.js",
+    "**/tests/playwright/reporter-3.test.js",
+    "**/tests/playwright/setup.js",
+    "**/tests/playwright/teardown.js",
+    "**/tests/web-test-runner/reporter-3.test.js"
+  ],
+  "overrides": [
+    {
+      "pattern": "**/tests/mocha/statuses.test.js",
+      "type": "ui",
+      "tool": "Mocha 1 Test Reporting"
+    },
+    {
+      "pattern": "**/tests/mocha/taxonomy-overrides.test.js",
+      "experience": "Mocha 2 Test Framework"
+    },
+    {
+      "pattern": "**/tests/mocha/hook-failures.test.js",
+      "type": "ui",
+      "tool": "Mocha Hook Failures Test Reporting"
+    },
+    {
+      "pattern": "**/tests/playwright/reporter-1.test.js",
+      "experience": "Playwright 1 Test Framework",
+      "tool": "Playwright 1 Test Reporting"
+    },
+    {
+      "pattern": "**/tests/playwright/reporter-2.test.js",
+      "type": "visual diff",
+      "experience": "Playwright 2 Test Framework"
+    },
+    {
+      "pattern": "**/tests/web-test-runner/reporter-1.test.js",
+      "experience": "WebTestRunner 1 Test Framework",
+      "tool": "WebTestRunner 1 Test Reporting"
+    },
+    {
+      "pattern": "**/tests/web-test-runner/reporter-2.test.js",
+      "type": "accessibility",
+      "experience": "WebTestRunner 2 Test Framework"
+    },
+    {
+      "pattern": "**/tests/webdriverio/reporter-1.test.js",
+      "type": "ui",
+      "tool": "WebdriverIO 1 Test Reporting"
+    },
+    {
+      "pattern": "**/tests/webdriverio/reporter-2.test.js",
+      "experience": "WebdriverIO 2 Test Framework"
+    }
+  ]
+}


### PR DESCRIPTION
Moves the integration test report configuration from the repo root into `test/integration/data/` and points all four framework configs (`mocha.cjs`, `playwright.js`, `web-test-runner.js`, `webdriverio.cjs`) at the new location via `reportConfigurationPath`. The root `d2l-test-reporting.config.json` is replaced with a general config that sets tool name and folder-based type overrides for unit and integration tests.

This is since we are going to start sending test data from here to test reporting so it needs to be "real" data not the dummy date for the integration tests.

https://desire2learn.atlassian.net/browse/QE-651