### PR TITLE
Add unit test reporting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,21 @@ jobs:
         with:
           bucket-path: ${{steps.coverage.outputs.destination}}
           publish-directory: ${{steps.coverage.outputs.source}}
+      - name: Report test results (Unit)
+        if: (!cancelled()) && github.actor != 'dependabot[bot]'
+        uses: Brightspace/test-reporting-action@main
+        with:
+          aws-access-key-id: ${{secrets.AWS_ACCESS_KEY_ID}}
+          aws-secret-access-key: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+          aws-session-token: ${{secrets.AWS_SESSION_TOKEN}}
+      - name: Report test results (Validation)
+        if: (!cancelled()) && github.actor != 'dependabot[bot]'
+        uses: Brightspace/test-reporting-action@main
+        with:
+          aws-access-key-id: ${{secrets.AWS_ACCESS_KEY_ID}}
+          aws-secret-access-key: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+          aws-session-token: ${{secrets.AWS_SESSION_TOKEN}}
+          report-path: ./d2l-test-report-validation.json
       - name: Generate test summary
         id: summary
         if: >

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,8 @@
+{
+  "spec": "test/unit/**/*.test.js",
+  "reporter": "src/reporters/mocha.cjs",
+  "reporter-options": [
+    "reportVersionLatest=true",
+    "reportConfigurationVersionLatest=true"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "test:integration:mocha": "mocha --config test/integration/data/configs/mocha.cjs || exit 0",
     "test:integration:playwright": "playwright test --config test/integration/data/configs/playwright.js || exit 0",
     "test:integration:web-test-runner": "wtr --config test/integration/data/configs/web-test-runner.js || exit 0",
-    "test:integration:validate-reports": "mocha test/integration/report-validation.test.js",
-    "test:unit": "mocha \"test/unit/**/*.test.js\""
+    "test:integration:validate-reports": "mocha --reporter-options reportPath=./d2l-test-report-validation.json --spec test/integration/report-validation.test.js",
+    "test:unit": "mocha"
   },
   "dependencies": {
     "@wdio/reporter": "^9",


### PR DESCRIPTION
Depends on #861 and https://github.com/Brightspace/repo-settings/pull/3871.

Adds `.mocharc.json` to configure the D2L mocha reporter for unit tests, generating reports at the default `./d2l-test-report.json` path. Updates `test:unit` to use mocha's config file and `test:integration:validate-reports` to write its report to a separate `./d2l-test-report-validation.json` path. Adds two `test-reporting-action` steps to CI to upload unit and validation reports.

https://desire2learn.atlassian.net/browse/QE-651