### PR TITLE
Rename config to configuration in v3 schema and add v3 cleaner

### DIFF
--- a/schemas/report/v3.json
+++ b/schemas/report/v3.json
@@ -154,7 +154,7 @@
             "type": "string",
             "format": "date-time"
           },
-          "config": {
+          "configuration": {
             "type": "object",
             "unevaluatedProperties": false,
             "properties": {

--- a/src/helpers/report-builder.cjs
+++ b/src/helpers/report-builder.cjs
@@ -34,7 +34,7 @@ const reportMemberPriority = [
 	'browser',
 	'framework',
 	'operatingSystem',
-	'config',
+	'configuration',
 	'timeout',
 	'started',
 	'duration',
@@ -308,7 +308,7 @@ class ReportDetailBuilder extends ReportBuilderBase {
 
 	setTimeout(timeout, options) {
 		if (this._reportVersionLatest) {
-			this._setNestedProperty('config', 'timeout', timeout, options);
+			this._setNestedProperty('configuration', 'timeout', timeout, options);
 		} else {
 			this._setProperty('timeout', timeout, options);
 		}

--- a/src/helpers/report.cjs
+++ b/src/helpers/report.cjs
@@ -351,10 +351,38 @@ const upgradeReportV2ToV3 = (report) => {
 			}
 
 			if (timeout != null) {
-				upgraded.config = { timeout };
+				upgraded.configuration = { timeout };
 			}
 
 			return upgraded;
+		})
+	};
+};
+
+const cleanReportV3 = (report) => {
+	return {
+		...report,
+		details: report.details.map((detail) => {
+			const { config, tool, experience, type, ...rest } = detail;
+			const cleaned = { ...rest };
+
+			if (config != null && cleaned.configuration == null) {
+				cleaned.configuration = config;
+			}
+
+			if (cleaned.taxonomy == null && (tool != null || type != null)) {
+				cleaned.taxonomy = {};
+
+				if (tool != null) {
+					cleaned.taxonomy.tool = tool;
+				}
+
+				if (type != null) {
+					cleaned.taxonomy.type = type;
+				}
+			}
+
+			return cleaned;
 		})
 	};
 };
@@ -382,7 +410,7 @@ const upgradeReport = (report) => {
 		case 2:
 			return upgradeReportV2ToV3(report);
 		case 3:
-			return report;
+			return cleanReportV3(report);
 		default:
 			throw new Error(`Unknown report version: ${reportVersion}`);
 	}
@@ -411,6 +439,10 @@ class Report {
 		}
 
 		const reportVersionOriginal = getReportVersion(report);
+
+		if (reportVersionOriginal === 3) {
+			report = cleanReportV3(report);
+		}
 
 		validateReport(report, `report (v${reportVersionOriginal})`);
 

--- a/test/integration/data/validation/test-report-mocha.js
+++ b/test/integration/data/validation/test-report-mocha.js
@@ -11,133 +11,133 @@ export const testReportLatestPartial = {
 		name: 'custom timeout > suite level timeout',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/mocha/custom-timeout.test.js' },
-		config: { timeout: 5000 },
+		configuration: { timeout: 5000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
 		name: 'custom timeout > test level timeout',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/mocha/custom-timeout.test.js' },
-		config: { timeout: 10000 },
+		configuration: { timeout: 10000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
 		name: 'hook failures > before all failure > test with before all failure',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/mocha/hook-failures.test.js' },
-		config: { timeout: 2000 },
+		configuration: { timeout: 2000 },
 		taxonomy: { tool: 'Mocha Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: 'hook failures > before each failure > test with before each failure',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/mocha/hook-failures.test.js' },
-		config: { timeout: 2000 },
+		configuration: { timeout: 2000 },
 		taxonomy: { tool: 'Mocha Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: 'hook failures > after each failure > test with after each failure',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/mocha/hook-failures.test.js' },
-		config: { timeout: 2000 },
+		configuration: { timeout: 2000 },
 		taxonomy: { tool: 'Mocha Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: 'hook failures > after all failure > test with after all failure',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/mocha/hook-failures.test.js' },
-		config: { timeout: 2000 },
+		configuration: { timeout: 2000 },
 		taxonomy: { tool: 'Mocha Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: 'hook failures > flaky before all > test with flaky before all',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/mocha/hook-failures.test.js' },
-		config: { timeout: 2000 },
+		configuration: { timeout: 2000 },
 		taxonomy: { tool: 'Mocha Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: 'hook failures > flaky before each > test with flaky before each',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/mocha/hook-failures.test.js' },
-		config: { timeout: 2000 },
+		configuration: { timeout: 2000 },
 		taxonomy: { tool: 'Mocha Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: 'hook failures > flaky after each > test with flaky after each',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/mocha/hook-failures.test.js' },
-		config: { timeout: 2000 },
+		configuration: { timeout: 2000 },
 		taxonomy: { tool: 'Mocha Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: 'hook failures > flaky after all > test with flaky after all',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/mocha/hook-failures.test.js' },
-		config: { timeout: 2000 },
+		configuration: { timeout: 2000 },
 		taxonomy: { tool: 'Mocha Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: 'special characters > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/mocha/special-characters.test.js' },
-		config: { timeout: 2000 },
+		configuration: { timeout: 2000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
 		name: 'statuses > passed',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/mocha/statuses.test.js' },
-		config: { timeout: 2000 },
+		configuration: { timeout: 2000 },
 		taxonomy: { tool: 'Mocha 1 Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: 'statuses > skipped',
 		status: 'skipped',
 		location: { file: 'test/integration/data/tests/mocha/statuses.test.js' },
-		config: { timeout: 2000 },
+		configuration: { timeout: 2000 },
 		taxonomy: { tool: 'Mocha 1 Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: 'statuses > flaky',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/mocha/statuses.test.js' },
-		config: { timeout: 2000 },
+		configuration: { timeout: 2000 },
 		taxonomy: { tool: 'Mocha 1 Test Reporting', type: 'ui' },
 		retries: 2
 	}, {
 		name: 'statuses > failed',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/mocha/statuses.test.js' },
-		config: { timeout: 2000 },
+		configuration: { timeout: 2000 },
 		taxonomy: { tool: 'Mocha 1 Test Reporting', type: 'ui' },
 		retries: 3
 	}, {
 		name: 'taxonomy overrides > passed',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/mocha/taxonomy-overrides.test.js' },
-		config: { timeout: 2000 },
+		configuration: { timeout: 2000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
 		name: 'taxonomy overrides > skipped',
 		status: 'skipped',
 		location: { file: 'test/integration/data/tests/mocha/taxonomy-overrides.test.js' },
-		config: { timeout: 2000 },
+		configuration: { timeout: 2000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
 		name: 'taxonomy overrides > flaky',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/mocha/taxonomy-overrides.test.js' },
-		config: { timeout: 2000 },
+		configuration: { timeout: 2000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 2
 	}, {
 		name: 'taxonomy overrides > failed',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/mocha/taxonomy-overrides.test.js' },
-		config: { timeout: 2000 },
+		configuration: { timeout: 2000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 3
 	}]

--- a/test/integration/data/validation/test-report-playwright.js
+++ b/test/integration/data/validation/test-report-playwright.js
@@ -16,7 +16,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -28,7 +28,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -40,7 +40,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -52,7 +52,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -64,7 +64,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -76,7 +76,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -88,7 +88,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -100,7 +100,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 3
 	}, {
@@ -112,7 +112,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -124,7 +124,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -136,7 +136,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -148,7 +148,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -160,7 +160,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 2
 	}, {
@@ -172,7 +172,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -184,7 +184,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -196,7 +196,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -208,7 +208,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 3
 	}, {
@@ -220,7 +220,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -232,7 +232,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 2
 	}, {
@@ -244,7 +244,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -256,7 +256,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'firefox',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -268,7 +268,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'firefox',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -280,7 +280,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'firefox',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -292,7 +292,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'firefox',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -304,7 +304,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'firefox',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -316,7 +316,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'firefox',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -328,7 +328,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'firefox',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 2
 	}, {
@@ -340,7 +340,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'firefox',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -352,7 +352,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'firefox',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 3
 	}, {
@@ -364,7 +364,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'firefox',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -376,7 +376,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -388,7 +388,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -400,7 +400,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -412,7 +412,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -424,7 +424,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -436,7 +436,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 3
 	}, {
@@ -448,7 +448,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -460,7 +460,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -472,7 +472,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -484,7 +484,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -496,7 +496,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -508,7 +508,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 2
 	}, {
@@ -520,7 +520,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -532,7 +532,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -544,7 +544,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -556,7 +556,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -568,7 +568,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -580,7 +580,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -592,7 +592,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -604,7 +604,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -616,7 +616,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 3
 	}, {
@@ -628,7 +628,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 2
 	}, {
@@ -640,7 +640,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'firefox',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -652,7 +652,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -664,7 +664,7 @@ export const testReportLatestPartial = {
 			column: 7
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -676,7 +676,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -688,7 +688,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'chromium',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -700,7 +700,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'firefox',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}, {
@@ -712,7 +712,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -724,7 +724,7 @@ export const testReportLatestPartial = {
 			column: 2
 		},
 		browser: 'webkit',
-		config: { timeout: 30000 },
+		configuration: { timeout: 30000 },
 		taxonomy: { tool: 'Test Reporting', type: 'visual diff' },
 		retries: 0
 	}]

--- a/test/integration/data/validation/test-report-web-test-runner.js
+++ b/test/integration/data/validation/test-report-web-test-runner.js
@@ -12,7 +12,7 @@ export const testReportLatestPartial = {
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'chrome',
-		config: { timeout: 120000 },
+		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'WebTestRunner 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -20,7 +20,7 @@ export const testReportLatestPartial = {
 		status: 'skipped',
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'chrome',
-		config: { timeout: 120000 },
+		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'WebTestRunner 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -28,7 +28,7 @@ export const testReportLatestPartial = {
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'chrome',
-		config: { timeout: 120000 },
+		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'WebTestRunner 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -36,7 +36,7 @@ export const testReportLatestPartial = {
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'chromium',
-		config: { timeout: 120000 },
+		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'Test Reporting', type: 'accessibility' },
 		retries: 0
 	}, {
@@ -44,7 +44,7 @@ export const testReportLatestPartial = {
 		status: 'skipped',
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'chromium',
-		config: { timeout: 120000 },
+		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'Test Reporting', type: 'accessibility' },
 		retries: 0
 	}, {
@@ -52,7 +52,7 @@ export const testReportLatestPartial = {
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'chromium',
-		config: { timeout: 120000 },
+		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'Test Reporting', type: 'accessibility' },
 		retries: 0
 	}, {
@@ -60,7 +60,7 @@ export const testReportLatestPartial = {
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'firefox',
-		config: { timeout: 120000 },
+		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'Test Reporting', type: 'accessibility' },
 		retries: 0
 	}, {
@@ -68,7 +68,7 @@ export const testReportLatestPartial = {
 		status: 'skipped',
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'firefox',
-		config: { timeout: 120000 },
+		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'Test Reporting', type: 'accessibility' },
 		retries: 0
 	}, {
@@ -76,7 +76,7 @@ export const testReportLatestPartial = {
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'firefox',
-		config: { timeout: 120000 },
+		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'Test Reporting', type: 'accessibility' },
 		retries: 0
 	}, {
@@ -84,7 +84,7 @@ export const testReportLatestPartial = {
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'webkit',
-		config: { timeout: 120000 },
+		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'WebTestRunner 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -92,7 +92,7 @@ export const testReportLatestPartial = {
 		status: 'skipped',
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'webkit',
-		config: { timeout: 120000 },
+		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'WebTestRunner 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -100,7 +100,7 @@ export const testReportLatestPartial = {
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'webkit',
-		config: { timeout: 120000 },
+		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'WebTestRunner 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -108,7 +108,7 @@ export const testReportLatestPartial = {
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'chrome',
-		config: { timeout: 120000 },
+		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'WebTestRunner 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
@@ -116,7 +116,7 @@ export const testReportLatestPartial = {
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'chromium',
-		config: { timeout: 120000 },
+		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'Test Reporting', type: 'accessibility' },
 		retries: 0
 	}, {
@@ -124,7 +124,7 @@ export const testReportLatestPartial = {
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-2.test.js' },
 		browser: 'firefox',
-		config: { timeout: 120000 },
+		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'Test Reporting', type: 'accessibility' },
 		retries: 0
 	}, {
@@ -132,7 +132,7 @@ export const testReportLatestPartial = {
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/web-test-runner/reporter-1.test.js' },
 		browser: 'webkit',
-		config: { timeout: 120000 },
+		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'WebTestRunner 1 Test Reporting', type: 'integration' },
 		retries: 0
 	}]

--- a/test/unit/report-builder.test.js
+++ b/test/unit/report-builder.test.js
@@ -159,13 +159,13 @@ describe('report builder', () => {
 			});
 
 			describe('timeout', () => {
-				it('sets under config', () => {
+				it('sets under configuration', () => {
 					const builder = new ReportBuilder('mocha', noopLogger, { reportWriter: () => { }, reportVersionLatest: true });
 					const detail = builder.getDetail('test-1');
 
 					detail.setTimeout(5000);
 
-					expect(detail.data.config.timeout).to.eq(5000);
+					expect(detail.data.configuration.timeout).to.eq(5000);
 				});
 
 				it('don\'t override by default', () => {
@@ -175,7 +175,7 @@ describe('report builder', () => {
 					detail.setTimeout(5000);
 					detail.setTimeout(10000);
 
-					expect(detail.data.config.timeout).to.eq(5000);
+					expect(detail.data.configuration.timeout).to.eq(5000);
 				});
 
 				it('override with option', () => {
@@ -185,7 +185,7 @@ describe('report builder', () => {
 					detail.setTimeout(5000);
 					detail.setTimeout(10000, { override: true });
 
-					expect(detail.data.config.timeout).to.eq(10000);
+					expect(detail.data.configuration.timeout).to.eq(10000);
 				});
 			});
 		});

--- a/test/unit/report.test.js
+++ b/test/unit/report.test.js
@@ -107,7 +107,7 @@ const testDetailsLatest = [{
 	location: { file: 'test/test-suite.js' },
 	taxonomy: { tool: 'My Tool', type: 'integration' },
 	started: testStarted,
-	config: { timeout: 30000 },
+	configuration: { timeout: 30000 },
 	duration: { final: 237, total: 549 },
 	status: 'passed',
 	retries: 1
@@ -116,7 +116,7 @@ const testDetailsLatest = [{
 	location: { file: 'test/test-suite.js' },
 	taxonomy: { tool: 'My Tool', type: 'integration' },
 	started: testStarted,
-	config: { timeout: 30000 },
+	configuration: { timeout: 30000 },
 	duration: { final: 237, total: 237 },
 	status: 'passed',
 	retries: 0
@@ -125,7 +125,7 @@ const testDetailsLatest = [{
 	location: { file: 'test/test-suite.js' },
 	taxonomy: { tool: 'My Tool', type: 'integration' },
 	started: testStarted,
-	config: { timeout: 30000 },
+	configuration: { timeout: 30000 },
 	duration: { final: 0, total: 0 },
 	status: 'skipped',
 	retries: 0
@@ -286,7 +286,7 @@ const testReportLatestFullOther = {
 		...testContextOther
 	}
 };
-const testDetailsLatestFromV1 = testDetailsLatest.map(({ config, ...rest }) => rest);
+const testDetailsLatestFromV1 = testDetailsLatest.map(({ configuration, ...rest }) => rest);
 const testReportLatestFromV1Full = {
 	...testReportLatestFull,
 	details: testDetailsLatestFromV1
@@ -338,6 +338,70 @@ const testReportLatestPartialContext = {
 			flaky: 1
 		}
 	}
+};
+
+const testDetailsOldV3 = [{
+	name: 'test suite > flaky test',
+	location: { file: 'test/test-suite.js' },
+	tool: 'My Tool',
+	experience: 'My Experience',
+	type: 'integration',
+	started: testStarted,
+	config: { timeout: 30000 },
+	duration: { final: 237, total: 549 },
+	status: 'passed',
+	retries: 1
+}, {
+	name: 'test suite > passing test',
+	location: { file: 'test/test-suite.js' },
+	tool: 'My Tool',
+	experience: 'My Experience',
+	type: 'integration',
+	started: testStarted,
+	config: { timeout: 30000 },
+	duration: { final: 237, total: 237 },
+	status: 'passed',
+	retries: 0
+}, {
+	name: 'test suite > skipped test',
+	location: { file: 'test/test-suite.js' },
+	tool: 'My Tool',
+	experience: 'My Experience',
+	type: 'integration',
+	started: testStarted,
+	config: { timeout: 30000 },
+	duration: { final: 0, total: 0 },
+	status: 'skipped',
+	retries: 0
+}];
+const testDetailsOldV3ConfigOnly = testDetailsLatest.map(({ configuration, ...rest }) => ({
+	...rest,
+	config: configuration
+}));
+const testReportOldV3Full = {
+	id: '00000000-0000-0000-0000-000000000000',
+	version: latestReportVersion,
+	summary: {
+		...testContext,
+		operatingSystem: 'linux',
+		framework: 'mocha',
+		started: testStarted,
+		status: 'passed',
+		duration: {
+			total: 23857
+		},
+		count: {
+			passed: 2,
+			failed: 0,
+			skipped: 1,
+			flaky: 1
+		}
+	},
+	details: testDetailsOldV3
+};
+const testReportOldV3ConfigOnly = {
+	...testReportOldV3Full,
+	details: testDetailsOldV3ConfigOnly
 };
 
 describe('report', () => {
@@ -762,6 +826,125 @@ describe('report', () => {
 					expect(report.getContext()).to.deep.equal(testContextOther);
 				});
 			});
+		});
+	});
+
+	describe(`legacy (old v3, cleans to v${latestReportVersion})`, () => {
+		it('cleans config to configuration', () => {
+			sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportOldV3ConfigOnly));
+
+			let report;
+
+			const wrapper = () => report = new Report(testReportPath);
+
+			expect(wrapper).to.not.throw();
+			expect(report.getVersionOriginal()).to.equal(latestReportVersion);
+			expect(report.getVersion()).to.equal(latestReportVersion);
+			expect(report.toJSON()).to.deep.equal(testReportLatestFull);
+		});
+
+		it('cleans flat taxonomy to nested taxonomy', () => {
+			sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportOldV3Full));
+
+			let report;
+
+			const wrapper = () => report = new Report(testReportPath);
+
+			expect(wrapper).to.not.throw();
+
+			const details = report.toJSON().details;
+
+			for (const detail of details) {
+				expect(detail).to.have.nested.property('taxonomy.tool');
+				expect(detail).to.have.nested.property('taxonomy.type');
+				expect(detail).to.not.have.property('tool');
+				expect(detail).to.not.have.property('type');
+			}
+		});
+
+		it('strips experience', () => {
+			sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportOldV3Full));
+
+			let report;
+
+			const wrapper = () => report = new Report(testReportPath);
+
+			expect(wrapper).to.not.throw();
+
+			for (const detail of report.toJSON().details) {
+				expect(detail).to.not.have.property('experience');
+			}
+		});
+
+		it('cleans all old v3 properties at once', () => {
+			sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportOldV3Full));
+
+			let report;
+
+			const wrapper = () => report = new Report(testReportPath);
+
+			expect(wrapper).to.not.throw();
+			expect(report.getVersionOriginal()).to.equal(latestReportVersion);
+			expect(report.getVersion()).to.equal(latestReportVersion);
+			expect(report.toJSON()).to.deep.equal(testReportLatestFull);
+		});
+
+		it('preserves already-clean v3 report', () => {
+			sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportLatestFull));
+
+			let report;
+
+			const wrapper = () => report = new Report(testReportPath);
+
+			expect(wrapper).to.not.throw();
+			expect(report.toJSON()).to.deep.equal(testReportLatestFull);
+		});
+
+		it('does not overwrite existing taxonomy', () => {
+			const mixedDetails = testDetailsLatest.map((detail) => ({
+				...detail,
+				tool: 'Stale Tool',
+				type: 'stale'
+			}));
+			const mixedReport = { ...testReportLatestFull, details: mixedDetails };
+
+			sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(mixedReport));
+
+			let report;
+
+			const wrapper = () => report = new Report(testReportPath);
+
+			expect(wrapper).to.not.throw();
+
+			const details = report.toJSON().details;
+
+			for (const detail of details) {
+				expect(detail.taxonomy.tool).to.equal('My Tool');
+				expect(detail.taxonomy.type).to.equal('integration');
+				expect(detail).to.not.have.property('tool');
+				expect(detail).to.not.have.property('type');
+			}
+		});
+
+		it('does not overwrite existing configuration', () => {
+			const mixedDetails = testDetailsLatest.map((detail) => ({
+				...detail,
+				config: { timeout: 99999 }
+			}));
+			const mixedReport = { ...testReportLatestFull, details: mixedDetails };
+
+			sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(mixedReport));
+
+			let report;
+
+			const wrapper = () => report = new Report(testReportPath);
+
+			expect(wrapper).to.not.throw();
+
+			for (const detail of report.toJSON().details) {
+				expect(detail.configuration.timeout).to.equal(30000);
+				expect(detail).to.not.have.property('config');
+			}
 		});
 	});
 });


### PR DESCRIPTION
Renames the `config` property to `configuration` in the v3 report schema, report builder output, and v2-to-v3 upgrade path.

Adds a `cleanReportV3` function that normalizes old v3 reports before schema validation. The cleaner handles reports that used the previous `config` property name, had flat `tool`/`type`/`experience` properties instead of nested `taxonomy`, or both. Existing `taxonomy` and `configuration` values are preserved when present alongside stale flat properties.

https://desire2learn.atlassian.net/browse/QE-651