### PR TITLE
Standardize issue labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,3 +1,38 @@
+- name: bug
+  description: Something isn't working
+  color: d73a4a
+- name: dependencies
+  description: Pull requests that update a dependency file
+  color: 0366d6
+- name: documentation
+  description: Improvements or additions to documentation
+  color: 0075ca
+- name: duplicate
+  description: This issue or pull request already exists
+  color: cfd3d7
+- name: enhancement
+  description: New feature or request
+  color: a2eeef
+- name: good first issue
+  description: Good for newcomers
+  color: 7057ff
+- name: help wanted
+  description: Extra attention is needed
+  color: 008672
+- name: invalid
+  description: This doesn't seem right
+  color: e4e669
+- name: javascript
+  description: Pull requests that update javascript code
+  color: 168700
+- name: question
+  description: Further information is requested
+  color: d876e3
 - name: stale
   description: This issue or pull request has been inactive for too long and will be closed soon
   color: 6b473a
+- name: wontfix
+  description: This will not be worked on
+  color: ffffff
+- name: released
+  color: ededed


### PR DESCRIPTION
Adds the full standard set of issue labels to `labels.yml`, including the `released` label for semantic release.

https://desire2learn.atlassian.net/browse/QE-2097