### PR TITLE
Make the new v3 report schema and v2 report configuration schema the default

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,8 +1,4 @@
 {
   "spec": "test/unit/**/*.test.js",
-  "reporter": "src/reporters/mocha.cjs",
-  "reporter-options": [
-    "reportVersionLatest=true",
-    "reportConfigurationVersionLatest=true"
-  ]
+  "reporter": "src/reporters/mocha.cjs"
 }

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ module.exports = {
 * `reportPath`: path to output the report to, relative to current working
   directory. Not required. Defaults to `./d2l-test-report.json`.
 * `reportConfigurationPath`: path to the D2L test reporting configuration file
-  for mapping test type, experience and tool to test code. Not required.
+  for mapping test type and tool to test code. Not required.
   Defaults to `./d2l-test-reporting.config.json`.
 
 #### [Playwright]
@@ -97,7 +97,7 @@ export default defineConfig({
 * `reportPath`: path to output the report to, relative to current working
   directory. Not required. Defaults to `./d2l-test-report.json`.
 * `reportConfigurationPath`: path to the D2L test reporting configuration file
-  for mapping test type, experience and tool to test code. Not required.
+  for mapping test type and tool to test code. Not required.
   Defaults to `./d2l-test-reporting.config.json`.
 
 #### [`@web/test-runner`]
@@ -132,7 +132,7 @@ export default {
 * `reportPath`: path to output the report to, relative to current working
   directory. Not required. Defaults to `./d2l-test-report.json`.
 * `reportConfigurationPath`: path to the D2L test reporting configuration file
-  for mapping test type, experience and tool to test code. Not required.
+  for mapping test type and tool to test code. Not required.
   Defaults to `./d2l-test-reporting.config.json`.
 
 #### [WebdriverIO]
@@ -190,7 +190,7 @@ exports.config = {
 * `reportPath`: path to output the report to, relative to current working
   directory. Not required. Defaults to `./d2l-test-report.json`.
 * `reportConfigurationPath`: path to the D2L test reporting configuration file
-  for mapping test type, experience and tool to test code. Not required.
+  for mapping test type and tool to test code. Not required.
   Defaults to `./d2l-test-reporting.config.json`.
 * `verbose`: enable verbose logging for debugging purposes. Not required.
   Defaults to `false`.
@@ -203,7 +203,7 @@ See the [ReportBuilder Guide](./docs/report-builder-guide.md) for a complete wal
 
 ## Report Configuration
 
-To have the test type, experience and tool mapped to test code, a D2L test
+To have the test type and tool mapped to test code, a D2L test
 reporting configuration file is required when using one of the reporters
 provided in this package.
 
@@ -218,7 +218,6 @@ file.
 ```json
 {
   "type": "UI Visual Diff",
-  "experience": "Experience",
   "tool": "Tool"
 }
 ```
@@ -229,17 +228,14 @@ file.
   "overrides": [
     {
       "pattern": "tests/feature-a/**/*",
-      "experience": "Experience A",
       "tool": "Feature A"
     },
     {
       "pattern": "tests/feature-b/**/*",
-      "experience": "Experience B",
       "tool": "Feature B"
     },
     {
       "pattern": "tests/feature-c.test.js",
-      "experience": "Experience C",
       "tool": "Feature C"
     }
   ]

--- a/docs/report-configuration-format.md
+++ b/docs/report-configuration-format.md
@@ -14,6 +14,32 @@ lists patterns to ignore when generating a report.
 {
   "type": "<Non-empty string matching pattern '^(?!\\s).+(?<!\\s)$', optional>",
   "tool": "<Non-empty string matching pattern '^(?!\\s).+(?<!\\s)$', optional>",
+  "ignorePatterns": [
+    "<Non-empty string matching pattern '^(?!\\s).+(?<!\\s)$'>"
+  ],
+  "overrides": [
+    {
+      "pattern": "<Non-empty string matching pattern '^(?!\\s).+(?<!\\s)$'>",
+      "type": "<Non-empty string matching pattern '^(?!\\s).+(?<!\\s)$', optional>",
+      "tool": "<Non-empty string matching pattern '^(?!\\s).+(?<!\\s)$', optional>"
+    }
+  ]
+}
+```
+
+If `type` is omitted at the top level then every entry in `overrides` must
+specify `type`. The same rule applies to `tool`. If `type` and `tool` are both
+omitted at the top level then `overrides` is required.
+
+## Previous
+
+<details>
+<summary>Version 1</summary>
+
+```json
+{
+  "type": "<Non-empty string matching pattern '^(?!\\s).+(?<!\\s)$', optional>",
+  "tool": "<Non-empty string matching pattern '^(?!\\s).+(?<!\\s)$', optional>",
   "experience": "<Non-empty string matching pattern '^(?!\\s).+(?<!\\s)$', optional>",
   "ignorePatterns": [
     "<Non-empty string matching pattern '^(?!\\s).+(?<!\\s)$'>"
@@ -29,7 +55,10 @@ lists patterns to ignore when generating a report.
 }
 ```
 
-If `type` is omitted at the top level then every entry in `overrides` must
-specify `type`. The same rule applies to `tool` and `experience`. If `type`,
-`tool` and `experience` are all omitted at the top level then `overrides` is
-required.
+Version 1 additionally supported an `experience` field at the top level and in
+each override. If `type` is omitted at the top level then every entry in
+`overrides` must specify `type`. The same rule applies to `tool` and
+`experience`. If `type`, `tool` and `experience` are all omitted at the top
+level then `overrides` is required.
+
+</details>

--- a/docs/report-format.md
+++ b/docs/report-format.md
@@ -15,6 +15,78 @@ stored in [AWS Timestream], please see [Storage Schema].
 ```json
 {
   "id": "<GUID>",
+  "version": 3,
+  "summary": {
+    "status": "<Must be 'passed' or 'failed'>",
+    "github": {
+      "organization": "<Non-empty string matching pattern '[A-Za-z0-9_.-]+'>",
+      "repository": "<Non-empty string matching pattern '[A-Za-z0-9_.-]+'>",
+      "workflow": "<Non-empty string matching pattern '^(?!\\s).+(?<!\\s)$'>",
+      "runId": "<Positive integer, can be 0>",
+      "runAttempt": "<Positive integer, must be 1 or greater>"
+    },
+    "git": {
+      "branch": "<Git branch this was generated for>",
+      "sha": "<Git SHA hash representing the commit this was generated for>"
+    },
+    "lms": {
+      "buildNumber": "<LMS build number matching pattern 'XX.XX.XX.XXXXX', optional>",
+      "instanceUrl": "<URI of the LMS instance, optional>"
+    },
+    "framework": "<Non-empty string matching pattern '^(?!\\s).+(?<!\\s)$>'",
+    "operatingSystem": "<Must be one of 'linux', 'windows' or 'mac'>",
+    "started": "<UTC timestamp>",
+    "duration": {
+      "total": "<Positive integer representing milliseconds, can be 0>"
+    },
+    "count": {
+      "passed": "<Positive integer, can be 0>",
+      "failed": "<Positive integer, can be 0>",
+      "skipped": "<Positive integer, can be 0>",
+      "flaky": "<Positive integer, can be 0>"
+    }
+  },
+  "details": [
+    {
+      "name": "<Non-empty string matching pattern '^(?!\\s).+(?<!\\s)$>'",
+      "status": "<Must be 'passed', 'skipped' or 'failed'>",
+      "location": {
+        "file": "<Non-empty string matching pattern '^(?!\\s).+(?<!\\s)$'>",
+        "line": "<Positive integer, can be 0, optional>",
+        "column": "<Positive integer, can be 0, optional>"
+      },
+      "taxonomy": {
+        "tool": "<Non-empty string matching pattern '^(?!\\s).+(?<!\\s)$', optional>",
+        "type": "<Non-empty string matching pattern '^(?!\\s).+(?<!\\s)$', optional>"
+      },
+      "browser": "<Can be 'chromium', 'chrome', 'firefox', 'webkit', 'safari' or 'edge', optional>",
+      "configuration": {
+        "timeout": "<Positive integer representing milliseconds, can be 0, optional>"
+      },
+      "started": "<Timestamp in UTC time>",
+      "duration": {
+        "total": "<Positive integer representing milliseconds, can be 0>",
+        "final": "<Positive integer representing milliseconds, can be 0>"
+      },
+      "github": {
+        "codeowners": [
+          "<Codeowner matching pattern '^@\\S+$', optional>"
+        ]
+      },
+      "retries": "<Positive integer, can be 0>"
+    }
+  ]
+}
+```
+
+## Previous
+
+<details>
+<summary>Version 2</summary>
+
+```json
+{
+  "id": "<GUID>",
   "version": 2,
   "summary": {
     "status": "<Must be 'passed' or 'failed'>",
@@ -67,7 +139,7 @@ stored in [AWS Timestream], please see [Storage Schema].
 }
 ```
 
-## Previous
+</details>
 
 <details>
 <summary>Version 1</summary>

--- a/src/helpers/report-builder.cjs
+++ b/src/helpers/report-builder.cjs
@@ -180,12 +180,11 @@ class ReportSummaryBuilder extends ReportBuilderBase {
 }
 
 class ReportDetailBuilder extends ReportBuilderBase {
-	constructor(reportConfiguration, codeowners, { reportVersionLatest = false } = {}) {
+	constructor(reportConfiguration, codeowners) {
 		super();
 
 		this._codeowners = codeowners;
 		this._reportConfiguration = reportConfiguration;
-		this._reportVersionLatest = reportVersionLatest;
 
 		this._setProperty('retries', 0);
 	}
@@ -211,20 +210,14 @@ class ReportDetailBuilder extends ReportBuilderBase {
 			return this;
 		}
 
-		const { type, tool, experience } = this._reportConfiguration.getTaxonomy(filePath);
+		const { type, tool } = this._reportConfiguration.getTaxonomy(filePath);
 
-		if (this._reportVersionLatest) {
-			if (type != null) {
-				this._setNestedProperty('taxonomy', 'type', type, options);
-			}
+		if (type != null) {
+			this._setNestedProperty('taxonomy', 'type', type, options);
+		}
 
-			if (tool != null) {
-				this._setNestedProperty('taxonomy', 'tool', tool, options);
-			}
-		} else {
-			this._setProperty('type', type, options);
-			this._setProperty('tool', tool, options);
-			this._setProperty('experience', experience, options);
+		if (tool != null) {
+			this._setNestedProperty('taxonomy', 'tool', tool, options);
 		}
 
 		if (this._codeowners) {
@@ -307,11 +300,7 @@ class ReportDetailBuilder extends ReportBuilderBase {
 	}
 
 	setTimeout(timeout, options) {
-		if (this._reportVersionLatest) {
-			this._setNestedProperty('configuration', 'timeout', timeout, options);
-		} else {
-			this._setProperty('timeout', timeout, options);
-		}
+		this._setNestedProperty('configuration', 'timeout', timeout, options);
 
 		return this;
 	}
@@ -327,18 +316,14 @@ class ReportBuilder extends ReportBuilderBase {
 			reportPath,
 			reportConfigurationPath,
 			reportWriter,
-			reportVersionLatest = false,
-			reportConfigurationVersionLatest = false,
 			verbose = false
 		} = options;
 
 		this._logger = logger;
 		this._verbose = verbose;
-		this._reportVersionLatest = reportVersionLatest;
 		this._reportConfiguration = new ReportConfiguration(
 			reportConfigurationPath,
-			logger,
-			{ configurationVersionLatest: reportConfigurationVersionLatest }
+			logger
 		);
 
 		if (reportWriter) {
@@ -362,18 +347,16 @@ class ReportBuilder extends ReportBuilderBase {
 		}
 
 		this._setProperty('id', randomUUID());
-		this._setProperty('version', reportVersionLatest ? latestReportVersion : 2);
+		this._setProperty('version', latestReportVersion);
 		this._setProperty('summary', new ReportSummaryBuilder(framework, this._logger));
 		this._setProperty('details', new Map());
 
 		this._codeowners = null;
 
-		if (this._data.version >= 3) {
-			try {
-				this._codeowners = new Codeowners();
-			} catch {
-				// No CODEOWNERS file found, skip
-			}
+		try {
+			this._codeowners = new Codeowners();
+		} catch {
+			// No CODEOWNERS file found, skip
 		}
 	}
 
@@ -397,8 +380,7 @@ class ReportBuilder extends ReportBuilderBase {
 				id,
 				new ReportDetailBuilder(
 					this._reportConfiguration,
-					this._codeowners,
-					{ reportVersionLatest: this._reportVersionLatest }
+					this._codeowners
 				)
 			);
 		}
@@ -430,8 +412,8 @@ class ReportBuilder extends ReportBuilderBase {
 			if (this._verbose) {
 				const { name, location } = detail;
 				const prefix = `Test '${name}' at '${location}' is missing`;
-				const type = this._reportVersionLatest ? detail.taxonomy?.type : detail.type;
-				const tool = this._reportVersionLatest ? detail.taxonomy?.tool : detail.tool;
+				const type = detail.taxonomy?.type;
+				const tool = detail.taxonomy?.tool;
 
 				if (!type) {
 					this._logger.warning(`${prefix} a 'type'`);
@@ -439,10 +421,6 @@ class ReportBuilder extends ReportBuilderBase {
 
 				if (!tool) {
 					this._logger.warning(`${prefix} a 'tool'`);
-				}
-
-				if (!this._reportVersionLatest && !detail.experience) {
-					this._logger.warning(`${prefix} an 'experience'`);
 				}
 			}
 		}

--- a/src/helpers/report-configuration.cjs
+++ b/src/helpers/report-configuration.cjs
@@ -2,7 +2,6 @@ const fs = require('node:fs');
 const { resolve } = require('node:path');
 const {
 	formatErrorAjv,
-	validateReportConfigurationV1Ajv,
 	validateReportConfigurationV2Ajv
 } = require('./schema.cjs');
 const { minimatch } = require('minimatch');
@@ -46,11 +45,9 @@ const upgradeReportConfigurationV1ToV2 = (configuration, logger) => {
 };
 
 class ReportConfiguration {
-	constructor(path, logger, { configurationVersionLatest = false } = {}) {
+	constructor(path, logger) {
 		let reportConfiguration;
 		let reportConfigurationPath;
-
-		this._configurationVersionLatest = configurationVersionLatest;
 
 		if (path) {
 			path = resolve(path);
@@ -86,16 +83,10 @@ class ReportConfiguration {
 			reportConfigurationPath = makeRelativeFilePath(path);
 		}
 
-		if (configurationVersionLatest) {
-			reportConfiguration = upgradeReportConfigurationV1ToV2(reportConfiguration, logger);
+		reportConfiguration = upgradeReportConfigurationV1ToV2(reportConfiguration, logger);
 
-			if (!validateReportConfigurationV2Ajv(reportConfiguration)) {
-				const { errors } = validateReportConfigurationV2Ajv;
-
-				throw new Error(formatErrorAjv(errors, { dataVar: 'report configuration' }));
-			}
-		} else if (!validateReportConfigurationV1Ajv(reportConfiguration)) {
-			const { errors } = validateReportConfigurationV1Ajv;
+		if (!validateReportConfigurationV2Ajv(reportConfiguration)) {
+			const { errors } = validateReportConfigurationV2Ajv;
 
 			throw new Error(formatErrorAjv(errors, { dataVar: 'report configuration' }));
 		}
@@ -118,17 +109,12 @@ class ReportConfiguration {
 			const {
 				pattern,
 				type: overriddenType,
-				tool: overriddenTool,
-				experience: overriddenExperience
+				tool: overriddenTool
 			} = override;
 
 			if (minimatch(filePath, pattern)) {
 				metadata.type = overriddenType?.toLowerCase();
 				metadata.tool = overriddenTool;
-
-				if (!this._configurationVersionLatest) {
-					metadata.experience = overriddenExperience;
-				}
 
 				break;
 			}
@@ -136,16 +122,11 @@ class ReportConfiguration {
 
 		const {
 			type: defaultType,
-			tool: defaultTool,
-			experience: defaultExperience
+			tool: defaultTool
 		} = this._reportConfiguration;
 
 		metadata.type = metadata.type ?? defaultType?.toLowerCase();
 		metadata.tool = metadata.tool ?? defaultTool;
-
-		if (!this._configurationVersionLatest) {
-			metadata.experience = metadata.experience ?? defaultExperience;
-		}
 
 		return metadata;
 	}
@@ -153,13 +134,7 @@ class ReportConfiguration {
 	hasTaxonomy(filePath) {
 		const taxonomy = this.getTaxonomy(filePath);
 
-		if (this._configurationVersionLatest) {
-			return taxonomy.type != null && taxonomy.tool != null;
-		}
-
-		return taxonomy.type != null &&
-			taxonomy.tool != null &&
-			taxonomy.experience != null;
+		return taxonomy.type != null && taxonomy.tool != null;
 	}
 
 	ignoreFilePath(filePath) {

--- a/src/helpers/report.cjs
+++ b/src/helpers/report.cjs
@@ -417,7 +417,7 @@ const upgradeReport = (report) => {
 };
 
 class Report {
-	constructor(path, { context, lmsInfo, overrideContext = false, upgradeToLatest = false } = {}) {
+	constructor(path, { context, lmsInfo, overrideContext = false } = {}) {
 		let report;
 
 		try {
@@ -454,7 +454,7 @@ class Report {
 			validateReport(report, `report (v${getReportVersion(report)})`);
 		}
 
-		if (upgradeToLatest && getReportVersion(report) < latestReportVersion) {
+		if (getReportVersion(report) < latestReportVersion) {
 			report = upgradeReport(report);
 
 			validateReport(report, `report (v${getReportVersion(report)})`);

--- a/src/reporters/webdriverio.cjs
+++ b/src/reporters/webdriverio.cjs
@@ -18,8 +18,6 @@ class WebdriverIO extends WDIOReporter {
 
 		this._baseReportPath = options.reportPath || './d2l-test-report.json';
 		this._reportConfigurationPath = options.reportConfigurationPath || './d2l-test-reporting.config.json';
-		this._reportVersionLatest = options.reportVersionLatest || false;
-		this._reportConfigurationVersionLatest = options.reportConfigurationVersionLatest || false;
 		this._verbose = options.verbose || false;
 		this._logger = logger;
 		this._report = null;
@@ -65,8 +63,6 @@ class WebdriverIO extends WDIOReporter {
 			this._report = new ReportBuilder('webdriverio', this._logger, {
 				reportPath: workerReportPath,
 				reportConfigurationPath: this._reportConfigurationPath,
-				reportVersionLatest: this._reportVersionLatest,
-				reportConfigurationVersionLatest: this._reportConfigurationVersionLatest,
 				verbose: this._verbose
 			});
 			console.log('[D2L Reporter] Initialized successfully');

--- a/test/integration/data/configs/mocha.cjs
+++ b/test/integration/data/configs/mocha.cjs
@@ -5,8 +5,6 @@ module.exports = {
 	reporterOptions: [
 		'reportPath=./d2l-test-report-mocha.json',
 		'reportConfigurationPath=./test/integration/data/d2l-test-reporting.config.json',
-		'reportVersionLatest=true',
-		'reportConfigurationVersionLatest=true',
 		'verbose=true'
 	]
 };

--- a/test/integration/data/configs/playwright.js
+++ b/test/integration/data/configs/playwright.js
@@ -3,8 +3,6 @@ import { defineConfig, devices } from '@playwright/test';
 const playwrightReporterOptions = {
 	reportPath: './d2l-test-report-playwright.json',
 	reportConfigurationPath: './test/integration/data/d2l-test-reporting.config.json',
-	reportVersionLatest: true,
-	reportConfigurationVersionLatest: true,
 	verbose: true
 };
 

--- a/test/integration/data/configs/web-test-runner.js
+++ b/test/integration/data/configs/web-test-runner.js
@@ -8,8 +8,6 @@ export default {
 		reporter({
 			reportPath: './d2l-test-report-web-test-runner.json',
 			reportConfigurationPath: './test/integration/data/d2l-test-reporting.config.json',
-			reportVersionLatest: true,
-			reportConfigurationVersionLatest: true,
 			verbose: true
 		})
 	],

--- a/test/integration/data/configs/webdriverio.cjs
+++ b/test/integration/data/configs/webdriverio.cjs
@@ -25,8 +25,6 @@ exports.config = {
 		[join(__dirname, '../../../../src/reporters/webdriverio.cjs'), {
 			reportPath: './d2l-test-report-webdriverio.json',
 			reportConfigurationPath: './test/integration/data/d2l-test-reporting.config.json',
-			reportVersionLatest: true,
-			reportConfigurationVersionLatest: true,
 			verbose: true
 		}]
 	],

--- a/test/integration/data/d2l-test-reporting.config.json
+++ b/test/integration/data/d2l-test-reporting.config.json
@@ -1,6 +1,5 @@
 {
   "type": "integration",
-  "experience": "Test Framework",
   "tool": "Test Reporting",
   "ignorePatterns": [
     "**/tests/mocha/ignored.test.js",
@@ -16,42 +15,30 @@
       "tool": "Mocha 1 Test Reporting"
     },
     {
-      "pattern": "**/tests/mocha/taxonomy-overrides.test.js",
-      "experience": "Mocha 2 Test Framework"
-    },
-    {
       "pattern": "**/tests/mocha/hook-failures.test.js",
       "type": "ui",
       "tool": "Mocha Hook Failures Test Reporting"
     },
     {
       "pattern": "**/tests/playwright/reporter-1.test.js",
-      "experience": "Playwright 1 Test Framework",
       "tool": "Playwright 1 Test Reporting"
     },
     {
       "pattern": "**/tests/playwright/reporter-2.test.js",
-      "type": "visual diff",
-      "experience": "Playwright 2 Test Framework"
+      "type": "visual diff"
     },
     {
       "pattern": "**/tests/web-test-runner/reporter-1.test.js",
-      "experience": "WebTestRunner 1 Test Framework",
       "tool": "WebTestRunner 1 Test Reporting"
     },
     {
       "pattern": "**/tests/web-test-runner/reporter-2.test.js",
-      "type": "accessibility",
-      "experience": "WebTestRunner 2 Test Framework"
+      "type": "accessibility"
     },
     {
       "pattern": "**/tests/webdriverio/reporter-1.test.js",
       "type": "ui",
       "tool": "WebdriverIO 1 Test Reporting"
-    },
-    {
-      "pattern": "**/tests/webdriverio/reporter-2.test.js",
-      "experience": "WebdriverIO 2 Test Framework"
     }
   ]
 }

--- a/test/unit/report-builder.test.js
+++ b/test/unit/report-builder.test.js
@@ -60,8 +60,7 @@ const configPathMatcher = match(
 );
 const testConfig = JSON.stringify({
 	type: 'unit',
-	tool: 'Test Reporting',
-	experience: 'Test Framework'
+	tool: 'Test Reporting'
 });
 
 describe('report builder', () => {
@@ -108,86 +107,28 @@ describe('report builder', () => {
 			expect(builder.data.id).to.be.a.uuid('v4');
 		});
 
-		describe('v2', () => {
-			it('sets version to 2', () => {
-				const builder = new ReportBuilder('mocha', noopLogger, { reportWriter: () => { } });
+		it('sets version to latest', () => {
+			const builder = new ReportBuilder('mocha', noopLogger, { reportWriter: () => { } });
 
-				expect(builder.data.version).to.eq(2);
-			});
-
-			it('produces loadable report', () => {
-				const builder = buildValidReport();
-
-				readFileSyncStub.returns(JSON.stringify(builder));
-
-				const report = new Report('./test-report.json', { context: testContext });
-
-				expect(report.getVersion()).to.eq(2);
-			});
-
-			it('does not set codeowners on details', () => {
-				const builder = buildValidReport();
-				const json = builder.toJSON();
-
-				expect(json.details[0]).to.not.have.nested.property('github.codeowners');
-			});
+			expect(builder.data.version).to.eq(latestReportVersion);
 		});
 
-		describe('v3', () => {
-			it('sets version to latest', () => {
-				const builder = new ReportBuilder('mocha', noopLogger, { reportWriter: () => { }, reportVersionLatest: true });
+		it('produces loadable report', () => {
+			const builder = buildValidReport();
 
-				expect(builder.data.version).to.eq(latestReportVersion);
-			});
+			readFileSyncStub.returns(JSON.stringify(builder));
 
-			it('produces loadable report', () => {
-				const builder = buildValidReport({ reportVersionLatest: true });
+			const report = new Report('./test-report.json', { context: testContext });
 
-				readFileSyncStub.returns(JSON.stringify(builder));
+			expect(report.getVersion()).to.eq(latestReportVersion);
+		});
 
-				const report = new Report('./test-report.json', { context: testContext });
+		it('sets codeowners on details', () => {
+			const builder = buildValidReport();
+			const json = builder.toJSON();
 
-				expect(report.getVersion()).to.eq(latestReportVersion);
-			});
-
-			it('sets codeowners on details', () => {
-				const builder = buildValidReport({ reportVersionLatest: true });
-				const json = builder.toJSON();
-
-				expect(json.details[0]).to.have.nested.property('github.codeowners');
-				expect(json.details[0].github.codeowners).to.be.an('array').that.is.not.empty;
-			});
-
-			describe('timeout', () => {
-				it('sets under configuration', () => {
-					const builder = new ReportBuilder('mocha', noopLogger, { reportWriter: () => { }, reportVersionLatest: true });
-					const detail = builder.getDetail('test-1');
-
-					detail.setTimeout(5000);
-
-					expect(detail.data.configuration.timeout).to.eq(5000);
-				});
-
-				it('don\'t override by default', () => {
-					const builder = new ReportBuilder('mocha', noopLogger, { reportWriter: () => { }, reportVersionLatest: true });
-					const detail = builder.getDetail('test-1');
-
-					detail.setTimeout(5000);
-					detail.setTimeout(10000);
-
-					expect(detail.data.configuration.timeout).to.eq(5000);
-				});
-
-				it('override with option', () => {
-					const builder = new ReportBuilder('mocha', noopLogger, { reportWriter: () => { }, reportVersionLatest: true });
-					const detail = builder.getDetail('test-1');
-
-					detail.setTimeout(5000);
-					detail.setTimeout(10000, { override: true });
-
-					expect(detail.data.configuration.timeout).to.eq(10000);
-				});
-			});
+			expect(json.details[0]).to.have.nested.property('github.codeowners');
+			expect(json.details[0].github.codeowners).to.be.an('array').that.is.not.empty;
 		});
 	});
 
@@ -427,21 +368,21 @@ describe('report builder', () => {
 			it('sets timeout', () => {
 				detail.setTimeout(10000);
 
-				expect(detail.data.timeout).to.eq(10000);
+				expect(detail.data.configuration.timeout).to.eq(10000);
 			});
 
 			it('don\'t override by default', () => {
 				detail.setTimeout(5000);
 				detail.setTimeout(10000);
 
-				expect(detail.data.timeout).to.eq(5000);
+				expect(detail.data.configuration.timeout).to.eq(5000);
 			});
 
 			it('override with option', () => {
 				detail.setTimeout(5000);
 				detail.setTimeout(10000, { override: true });
 
-				expect(detail.data.timeout).to.eq(10000);
+				expect(detail.data.configuration.timeout).to.eq(10000);
 			});
 		});
 
@@ -649,7 +590,6 @@ describe('report builder', () => {
 			const config = JSON.stringify({
 				type: 'integration',
 				tool: 'test',
-				experience: 'test',
 				ignorePatterns: ['**/ignored/**']
 			});
 
@@ -669,7 +609,6 @@ describe('report builder', () => {
 			const config = JSON.stringify({
 				type: 'integration',
 				tool: 'test',
-				experience: 'test',
 				ignorePatterns: ['**/ignored/**']
 			});
 

--- a/test/unit/report-configuration.test.js
+++ b/test/unit/report-configuration.test.js
@@ -1,0 +1,239 @@
+import { createSandbox } from 'sinon';
+import { expect } from 'chai';
+import fs from 'node:fs';
+import { ReportConfiguration } from '../../src/helpers/report-configuration.cjs';
+
+const configPath = './d2l-test-reporting.config.json';
+
+describe('report configuration', () => {
+	let sandbox;
+	let logger;
+
+	before(() => sandbox = createSandbox());
+
+	beforeEach(() => {
+		logger = {
+			info: sandbox.spy(),
+			warning: sandbox.spy(),
+			error: sandbox.spy(),
+			location: sandbox.spy()
+		};
+	});
+
+	afterEach(() => sandbox.restore());
+
+	const loadConfig = (config) => {
+		sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(config));
+
+		return new ReportConfiguration(configPath, logger);
+	};
+
+	const warningMessages = () => logger.warning.getCalls().map(call => call.args[0]);
+
+	describe('legacy (v1, upgrades to v2)', () => {
+		describe('top-level', () => {
+			it('strips experience', () => {
+				const config = loadConfig({
+					type: 'integration',
+					tool: 'Test Reporting',
+					experience: 'Test Framework'
+				});
+
+				expect(config.toJSON()).to.deep.equal({
+					type: 'integration',
+					tool: 'Test Reporting'
+				});
+			});
+
+			it('warns when experience stripped', () => {
+				loadConfig({
+					type: 'integration',
+					tool: 'Test Reporting',
+					experience: 'Test Framework'
+				});
+
+				expect(warningMessages().some(msg => msg.includes('\'experience\' is no longer supported'))).to.be.true;
+			});
+		});
+
+		describe('overrides', () => {
+			it('strips experience', () => {
+				const config = loadConfig({
+					type: 'integration',
+					tool: 'Test Reporting',
+					overrides: [{
+						pattern: '**/special.test.js',
+						tool: 'Special Tool',
+						experience: 'Special Experience'
+					}]
+				});
+				const { overrides } = config.toJSON();
+
+				expect(overrides).to.have.lengthOf(1);
+				expect(overrides[0]).to.deep.equal({
+					pattern: '**/special.test.js',
+					tool: 'Special Tool'
+				});
+			});
+
+			it('warns when experience stripped', () => {
+				loadConfig({
+					type: 'integration',
+					tool: 'Test Reporting',
+					overrides: [{
+						pattern: '**/special.test.js',
+						tool: 'Special Tool',
+						experience: 'Special Experience'
+					}]
+				});
+
+				expect(warningMessages().some(msg => msg.includes('**/special.test.js') && msg.includes('\'experience\''))).to.be.true;
+			});
+
+			it('drops override with only pattern', () => {
+				const config = loadConfig({
+					type: 'integration',
+					tool: 'Test Reporting',
+					overrides: [{
+						pattern: '**/special.test.js',
+						experience: 'Special Experience'
+					}]
+				});
+
+				expect(config.toJSON()).to.not.have.property('overrides');
+			});
+
+			it('warns when override dropped', () => {
+				loadConfig({
+					type: 'integration',
+					tool: 'Test Reporting',
+					overrides: [{
+						pattern: '**/special.test.js',
+						experience: 'Special Experience'
+					}]
+				});
+
+				expect(warningMessages().some(msg => msg.includes('**/special.test.js') && msg.includes('will be dropped'))).to.be.true;
+			});
+		});
+
+		it('preserves valid v2 config', () => {
+			const input = {
+				type: 'integration',
+				tool: 'Test Reporting',
+				overrides: [{
+					pattern: '**/special.test.js',
+					tool: 'Special Tool'
+				}]
+			};
+			const config = loadConfig(input);
+
+			expect(config.toJSON()).to.deep.equal(input);
+			expect(logger.warning.called).to.be.false;
+		});
+	});
+
+	describe('validation', () => {
+		describe('throws', () => {
+			it('for invalid config', () => {
+				sandbox.stub(fs, 'readFileSync').returns(JSON.stringify({}));
+
+				expect(() => new ReportConfiguration(configPath, logger)).to.throw(/report configuration/);
+			});
+
+			it('when unparseable', () => {
+				sandbox.stub(fs, 'readFileSync').returns('not json');
+
+				expect(() => new ReportConfiguration(configPath, logger)).to.throw('Unable to read/parse');
+			});
+		});
+
+		it('empty without config file', () => {
+			sandbox.stub(fs, 'readFileSync').throws(new Error('ENOENT'));
+
+			const config = new ReportConfiguration(undefined, logger);
+
+			expect(config.toJSON()).to.deep.equal({});
+		});
+	});
+
+	describe('taxonomy', () => {
+		it('lowercases type', () => {
+			const config = loadConfig({ type: 'UI', tool: 'My Tool' });
+
+			expect(config.getTaxonomy('test/example.test.js')).to.deep.equal({
+				type: 'ui',
+				tool: 'My Tool'
+			});
+		});
+
+		it('applies matching override', () => {
+			const config = loadConfig({
+				type: 'integration',
+				tool: 'Default Tool',
+				overrides: [{
+					pattern: '**/special.test.js',
+					type: 'UI',
+					tool: 'Special Tool'
+				}]
+			});
+
+			expect(config.getTaxonomy('test/special.test.js')).to.deep.equal({
+				type: 'ui',
+				tool: 'Special Tool'
+			});
+		});
+
+		it('omits experience', () => {
+			const config = loadConfig({
+				type: 'integration',
+				tool: 'Test Reporting',
+				experience: 'Test Framework'
+			});
+
+			expect(config.getTaxonomy('test/example.test.js')).to.not.have.property('experience');
+		});
+
+		describe('completeness', () => {
+			it('true when type and tool resolve', () => {
+				const config = loadConfig({ type: 'integration', tool: 'Test Reporting' });
+
+				expect(config.hasTaxonomy('test/example.test.js')).to.be.true;
+			});
+
+			it('false when tool missing', () => {
+				const config = loadConfig({
+					type: 'integration',
+					overrides: [{
+						pattern: '**/special.test.js',
+						tool: 'Special Tool'
+					}]
+				});
+
+				expect(config.hasTaxonomy('test/example.test.js')).to.be.false;
+			});
+		});
+	});
+
+	describe('ignore', () => {
+		it('true when matching', () => {
+			const config = loadConfig({
+				type: 'integration',
+				tool: 'Test Reporting',
+				ignorePatterns: ['**/ignored/**']
+			});
+
+			expect(config.ignoreFilePath('test/ignored/example.test.js')).to.be.true;
+		});
+
+		it('false when not matching', () => {
+			const config = loadConfig({
+				type: 'integration',
+				tool: 'Test Reporting',
+				ignorePatterns: ['**/ignored/**']
+			});
+
+			expect(config.ignoreFilePath('test/example.test.js')).to.be.false;
+		});
+	});
+});

--- a/test/unit/report.test.js
+++ b/test/unit/report.test.js
@@ -420,7 +420,7 @@ describe('report', () => {
 
 				let report;
 
-				const wrapper = () => report = (new Report(testReportPath, { upgradeToLatest: true }));
+				const wrapper = () => report = (new Report(testReportPath));
 
 				expect(wrapper).to.not.throw();
 				expect(report.getVersionOriginal()).to.equal(testReportCurrentVersion);
@@ -436,8 +436,7 @@ describe('report', () => {
 
 					const reportOptions = {
 						context: testContextOther,
-						overrideContext: true,
-						upgradeToLatest: true
+						overrideContext: true
 					};
 					let report;
 
@@ -455,8 +454,7 @@ describe('report', () => {
 					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportV1Full));
 
 					const reportOptions = {
-						context: testContextOther,
-						upgradeToLatest: true
+						context: testContextOther
 					};
 					let report;
 
@@ -477,8 +475,7 @@ describe('report', () => {
 
 					const reportOptions = {
 						context: testContextOther,
-						overrideContext: true,
-						upgradeToLatest: true
+						overrideContext: true
 					};
 					let report;
 
@@ -496,8 +493,7 @@ describe('report', () => {
 					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportV1NoContext));
 
 					const reportOptions = {
-						context: testContextOther,
-						upgradeToLatest: true
+						context: testContextOther
 					};
 					let report;
 
@@ -518,8 +514,7 @@ describe('report', () => {
 
 					const reportOptions = {
 						context: testContextOther,
-						overrideContext: true,
-						upgradeToLatest: true
+						overrideContext: true
 					};
 					let report;
 
@@ -537,8 +532,7 @@ describe('report', () => {
 					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportV1PartialContext));
 
 					const reportOptions = {
-						context: testContextOther,
-						upgradeToLatest: true
+						context: testContextOther
 					};
 					let report;
 
@@ -564,7 +558,7 @@ describe('report', () => {
 
 				let report;
 
-				const wrapper = () => report = (new Report(testReportPath, { upgradeToLatest: true }));
+				const wrapper = () => report = (new Report(testReportPath));
 
 				expect(wrapper).to.not.throw();
 				expect(report.getVersionOriginal()).to.equal(testReportCurrentVersion);
@@ -580,8 +574,7 @@ describe('report', () => {
 
 					const reportOptions = {
 						context: testContextOther,
-						overrideContext: true,
-						upgradeToLatest: true
+						overrideContext: true
 					};
 					let report;
 
@@ -599,8 +592,7 @@ describe('report', () => {
 					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportV2Full));
 
 					const reportOptions = {
-						context: testContextOther,
-						upgradeToLatest: true
+						context: testContextOther
 					};
 					let report;
 
@@ -621,8 +613,7 @@ describe('report', () => {
 
 					const reportOptions = {
 						context: testContextOther,
-						overrideContext: true,
-						upgradeToLatest: true
+						overrideContext: true
 					};
 					let report;
 
@@ -640,8 +631,7 @@ describe('report', () => {
 					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportV2NoContext));
 
 					const reportOptions = {
-						context: testContextOther,
-						upgradeToLatest: true
+						context: testContextOther
 					};
 					let report;
 
@@ -662,8 +652,7 @@ describe('report', () => {
 
 					const reportOptions = {
 						context: testContextOther,
-						overrideContext: true,
-						upgradeToLatest: true
+						overrideContext: true
 					};
 					let report;
 
@@ -681,8 +670,7 @@ describe('report', () => {
 					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportV2PartialContext));
 
 					const reportOptions = {
-						context: testContextOther,
-						upgradeToLatest: true
+						context: testContextOther
 					};
 					let report;
 


### PR DESCRIPTION
The current version has some flags we can set to enable the use of the v3 schema by default for the report builder and for the report object as well as some flags for enabling the v2 of the report schema tat drops the `experience` from it's structure. This makes a breaking change to remove those flags and make the new version of things the default.

> [!IMPORTANT]
> Will merge this tomorrow morning so we can deal with any fallout tomorrow and Thursday.

https://desire2learn.atlassian.net/browse/QE-651