### PR TITLE
fix: fall back to default logger in report configuration

### DIFF
--- a/src/helpers/report-configuration.cjs
+++ b/src/helpers/report-configuration.cjs
@@ -8,6 +8,9 @@ const { minimatch } = require('minimatch');
 const { makeRelativeFilePath } = require('./system.cjs');
 
 const defaultConfigurationPath = './d2l-test-reporting.config.json';
+const defaultLogger = {
+	warning: (message) => console.warn(message)
+};
 
 const upgradeReportConfigurationV1ToV2 = (configuration, logger) => {
 	const { experience, overrides, ...rest } = configuration;
@@ -46,6 +49,8 @@ const upgradeReportConfigurationV1ToV2 = (configuration, logger) => {
 
 class ReportConfiguration {
 	constructor(path, logger) {
+		logger ??= defaultLogger;
+
 		let reportConfiguration;
 		let reportConfigurationPath;
 


### PR DESCRIPTION
The downstream should pass a logger but if not then it will throw errors. Just adding a fallback logger.

https://desire2learn.atlassian.net/browse/QE-651