### PR TITLE
fix: keep report internals private

### DIFF
--- a/src/helpers/report-builder.cjs
+++ b/src/helpers/report-builder.cjs
@@ -108,10 +108,12 @@ class ReportBuilderBase {
 }
 
 class ReportSummaryBuilder extends ReportBuilderBase {
+	#logger;
+
 	constructor(framework, logger) {
 		super();
 
-		this._logger = logger;
+		this.#logger = logger;
 
 		this._setProperty('operatingSystem', getOperatingSystemType());
 		this._setProperty('framework', framework);
@@ -124,7 +126,7 @@ class ReportSummaryBuilder extends ReportBuilderBase {
 			this._setProperty('github', github, { override: true });
 			this._setProperty('git', git, { override: true });
 		} else {
-			this._logger.warning('D2L test report will not contain GitHub context details');
+			this.#logger.warning('D2L test report will not contain GitHub context details');
 		}
 
 		return this;
@@ -180,11 +182,14 @@ class ReportSummaryBuilder extends ReportBuilderBase {
 }
 
 class ReportDetailBuilder extends ReportBuilderBase {
+	#codeowners;
+	#reportConfiguration;
+
 	constructor(reportConfiguration, codeowners) {
 		super();
 
-		this._codeowners = codeowners;
-		this._reportConfiguration = reportConfiguration;
+		this.#codeowners = codeowners;
+		this.#reportConfiguration = reportConfiguration;
 
 		this._setProperty('retries', 0);
 	}
@@ -206,11 +211,11 @@ class ReportDetailBuilder extends ReportBuilderBase {
 
 		this._setNestedProperty('location', 'file', filePath, options);
 
-		if (!this._reportConfiguration) {
+		if (!this.#reportConfiguration) {
 			return this;
 		}
 
-		const { type, tool } = this._reportConfiguration.getTaxonomy(filePath);
+		const { type, tool } = this.#reportConfiguration.getTaxonomy(filePath);
 
 		if (type != null) {
 			this._setNestedProperty('taxonomy', 'type', type, options);
@@ -220,8 +225,8 @@ class ReportDetailBuilder extends ReportBuilderBase {
 			this._setNestedProperty('taxonomy', 'tool', tool, options);
 		}
 
-		if (this._codeowners) {
-			const owners = this._codeowners.getOwner(filePath);
+		if (this.#codeowners) {
+			const owners = this.#codeowners.getOwner(filePath);
 
 			if (owners.length > 0) {
 				this._setNestedProperty('github', 'codeowners', owners, options);
@@ -309,6 +314,12 @@ class ReportDetailBuilder extends ReportBuilderBase {
 class ReportBuilder extends ReportBuilderBase {
 	static SupportedBrowsers = latestSupportedBrowsers;
 
+	#codeowners;
+	#logger;
+	#reportConfiguration;
+	#verbose;
+	#writeReport;
+
 	constructor(framework, logger, options) {
 		super();
 
@@ -319,9 +330,9 @@ class ReportBuilder extends ReportBuilderBase {
 			verbose = false
 		} = options;
 
-		this._logger = logger;
-		this._verbose = verbose;
-		this._reportConfiguration = new ReportConfiguration(
+		this.#logger = logger;
+		this.#verbose = verbose;
+		this.#reportConfiguration = new ReportConfiguration(
 			reportConfigurationPath,
 			logger
 		);
@@ -331,41 +342,41 @@ class ReportBuilder extends ReportBuilderBase {
 				throw new Error('must supply only one of \'reportPath\' or \'reportWriter\'');
 			}
 
-			this._writeReport = (reportData) => {
+			this.#writeReport = (reportData) => {
 				reportWriter(reportData);
 
-				this._logger.info('D2L test report available at output location');
+				this.#logger.info('D2L test report available at output location');
 			};
 		} else {
 			const reportPathFinal = determineReportPath(reportPath);
 
-			this._writeReport = (reportData) => {
+			this.#writeReport = (reportData) => {
 				writeFileSync(reportPathFinal, reportData, 'utf8');
 
-				this._logger.location('D2L test report available at', reportPathFinal);
+				this.#logger.location('D2L test report available at', reportPathFinal);
 			};
 		}
 
 		this._setProperty('id', randomUUID());
 		this._setProperty('version', latestReportVersion);
-		this._setProperty('summary', new ReportSummaryBuilder(framework, this._logger));
+		this._setProperty('summary', new ReportSummaryBuilder(framework, this.#logger));
 		this._setProperty('details', new Map());
 
-		this._codeowners = null;
+		this.#codeowners = null;
 
 		try {
-			this._codeowners = new Codeowners();
+			this.#codeowners = new Codeowners();
 		} catch {
 			// No CODEOWNERS file found, skip
 		}
 	}
 
 	ignoreFilePath(filePath) {
-		if (!this._reportConfiguration) {
+		if (!this.#reportConfiguration) {
 			return false;
 		}
 
-		return this._reportConfiguration.ignoreFilePath(filePath);
+		return this.#reportConfiguration.ignoreFilePath(filePath);
 	}
 
 	getSummary() {
@@ -379,8 +390,8 @@ class ReportBuilder extends ReportBuilderBase {
 			details.set(
 				id,
 				new ReportDetailBuilder(
-					this._reportConfiguration,
-					this._codeowners
+					this.#reportConfiguration,
+					this.#codeowners
 				)
 			);
 		}
@@ -409,18 +420,18 @@ class ReportBuilder extends ReportBuilderBase {
 				countFailed++;
 			}
 
-			if (this._verbose) {
+			if (this.#verbose) {
 				const { name, location } = detail;
 				const prefix = `Test '${name}' at '${location}' is missing`;
 				const type = detail.taxonomy?.type;
 				const tool = detail.taxonomy?.tool;
 
 				if (!type) {
-					this._logger.warning(`${prefix} a 'type'`);
+					this.#logger.warning(`${prefix} a 'type'`);
 				}
 
 				if (!tool) {
-					this._logger.warning(`${prefix} a 'tool'`);
+					this.#logger.warning(`${prefix} a 'tool'`);
 				}
 			}
 		}
@@ -448,9 +459,9 @@ class ReportBuilder extends ReportBuilderBase {
 		try {
 			const reportData = JSON.stringify(this, reportMemberPriority);
 
-			this._writeReport(reportData);
+			this.#writeReport(reportData);
 		} catch {
-			this._logger.error('Failed to generate D2L test report');
+			this.#logger.error('Failed to generate D2L test report');
 		}
 	}
 }

--- a/src/helpers/report-configuration.cjs
+++ b/src/helpers/report-configuration.cjs
@@ -48,6 +48,9 @@ const upgradeReportConfigurationV1ToV2 = (configuration, logger) => {
 };
 
 class ReportConfiguration {
+	#reportConfiguration;
+	#reportConfigurationPath;
+
 	constructor(path, logger) {
 		logger ??= defaultLogger;
 
@@ -74,7 +77,7 @@ class ReportConfiguration {
 			try {
 				contents = fs.readFileSync(path, 'utf8');
 			} catch {
-				this._reportConfiguration = {};
+				this.#reportConfiguration = {};
 
 				return;
 			}
@@ -96,18 +99,18 @@ class ReportConfiguration {
 			throw new Error(formatErrorAjv(errors, { dataVar: 'report configuration' }));
 		}
 
-		this._reportConfigurationPath = reportConfigurationPath;
-		this._reportConfiguration = reportConfiguration;
+		this.#reportConfigurationPath = reportConfigurationPath;
+		this.#reportConfiguration = reportConfiguration;
 	}
 
 	getPath() {
-		return this._reportConfigurationPath;
+		return this.#reportConfigurationPath;
 	}
 
 	getTaxonomy(filePath) {
 		filePath = makeRelativeFilePath(filePath);
 
-		const { overrides } = this._reportConfiguration;
+		const { overrides } = this.#reportConfiguration;
 		const metadata = {};
 
 		for (const override of overrides ?? []) {
@@ -128,7 +131,7 @@ class ReportConfiguration {
 		const {
 			type: defaultType,
 			tool: defaultTool
-		} = this._reportConfiguration;
+		} = this.#reportConfiguration;
 
 		metadata.type = metadata.type ?? defaultType?.toLowerCase();
 		metadata.tool = metadata.tool ?? defaultTool;
@@ -145,7 +148,7 @@ class ReportConfiguration {
 	ignoreFilePath(filePath) {
 		filePath = makeRelativeFilePath(filePath);
 
-		const { ignorePatterns } = this._reportConfiguration;
+		const { ignorePatterns } = this.#reportConfiguration;
 
 		for (const ignorePattern of ignorePatterns ?? []) {
 			if (minimatch(filePath, ignorePattern)) {
@@ -157,7 +160,7 @@ class ReportConfiguration {
 	}
 
 	toJSON() {
-		return this._reportConfiguration;
+		return this.#reportConfiguration;
 	}
 }
 

--- a/src/helpers/report.cjs
+++ b/src/helpers/report.cjs
@@ -417,6 +417,10 @@ const upgradeReport = (report) => {
 };
 
 class Report {
+	#report;
+	#reportPath;
+	#reportVersionOriginal;
+
 	constructor(path, { context, lmsInfo, overrideContext = false } = {}) {
 		let report;
 
@@ -446,7 +450,7 @@ class Report {
 
 		validateReport(report, `report (v${reportVersionOriginal})`);
 
-		this._reportVersionOriginal = reportVersionOriginal;
+		this.#reportVersionOriginal = reportVersionOriginal;
 
 		if (reportVersionOriginal < 2) {
 			report = upgradeReportToV2(report);
@@ -462,34 +466,34 @@ class Report {
 			throw new Error(`Unsupported report version specified: ${reportVersionOriginal}`);
 		}
 
-		this._report = report;
-		this._reportPath = makeRelativeFilePath(path);
+		this.#report = report;
+		this.#reportPath = makeRelativeFilePath(path);
 	}
 
 	getPath() {
-		return this._reportPath;
+		return this.#reportPath;
 	}
 
 	getId() {
-		return this._report.id;
+		return this.#report.id;
 	}
 
 	getVersionOriginal() {
-		return this._reportVersionOriginal;
+		return this.#reportVersionOriginal;
 	}
 
 	getVersion() {
-		return this._report.version;
+		return this.#report.version;
 	}
 
 	getContext() {
-		const { summary: { github, git } } = this._report;
+		const { summary: { github, git } } = this.#report;
 
 		return { github, git };
 	}
 
 	toJSON() {
-		return this._report;
+		return this.#report;
 	}
 }
 

--- a/src/reporters/mocha.cjs
+++ b/src/reporters/mocha.cjs
@@ -32,57 +32,60 @@ const makeDetailId = (file, name) => {
 };
 
 class TestReportingMochaReporter extends Spec {
+	#logger;
+	#report;
+
 	constructor(runner, options) {
 		super(runner, options);
 
 		const { stats } = runner;
 		const { reporterOptions = {} } = options;
 
-		this._logger = new MochaLogger();
+		this.#logger = new MochaLogger();
 
 		try {
-			const report = new ReportBuilder('mocha', this._logger, reporterOptions);
+			const report = new ReportBuilder('mocha', this.#logger, reporterOptions);
 
-			this._report = report;
+			this.#report = report;
 		} catch ({ message }) {
-			this._logger.error('Failed to initialize D2L test report builder, report will not be generated');
-			this._logger.error(message);
+			this.#logger.error('Failed to initialize D2L test report builder, report will not be generated');
+			this.#logger.error(message);
 
 			return;
 		}
 
 		runner
-			.once(EVENT_RUN_BEGIN, () => this._onRunBegin(stats))
-			.on(EVENT_TEST_PENDING, test => this._onTestPending(test))
-			.on(EVENT_TEST_BEGIN, test => this._onTestBegin(test))
-			.on(EVENT_TEST_END, test => this._onTestEnd(test))
-			.on(EVENT_TEST_FAIL, test => this._onTestFail(test))
-			.on(EVENT_TEST_RETRY, test => this._onTestRetry(test))
-			.once(EVENT_RUN_END, () => this._onRunEnd(stats));
+			.once(EVENT_RUN_BEGIN, () => this.#onRunBegin(stats))
+			.on(EVENT_TEST_PENDING, test => this.#onTestPending(test))
+			.on(EVENT_TEST_BEGIN, test => this.#onTestBegin(test))
+			.on(EVENT_TEST_END, test => this.#onTestEnd(test))
+			.on(EVENT_TEST_FAIL, test => this.#onTestFail(test))
+			.on(EVENT_TEST_RETRY, test => this.#onTestRetry(test))
+			.once(EVENT_RUN_END, () => this.#onRunEnd(stats));
 	}
 
-	_onRunBegin(stats) {
-		this._report
+	#onRunBegin(stats) {
+		this.#report
 			.getSummary()
 			.addContext()
 			.setStarted(stats.start.toISOString());
 	}
 
-	_onTestPending(test) {
-		this._onTestBegin(test);
+	#onTestPending(test) {
+		this.#onTestBegin(test);
 	}
 
-	_onTestBegin(test) {
+	#onTestBegin(test) {
 		const { file, _timeout } = test;
 
-		if (this._report.ignoreFilePath(file)) {
+		if (this.#report.ignoreFilePath(file)) {
 			return;
 		}
 
 		const name = makeDetailName(test);
 		const id = makeDetailId(file, name);
 
-		this._report
+		this.#report
 			.getDetail(id)
 			.setName(name)
 			.setLocationFile(file)
@@ -90,10 +93,10 @@ class TestReportingMochaReporter extends Spec {
 			.setTimeout(_timeout); // using internal property, not ideal
 	}
 
-	_onTestRetry(test) {
+	#onTestRetry(test) {
 		const { file } = test;
 
-		if (this._report.ignoreFilePath(file)) {
+		if (this.#report.ignoreFilePath(file)) {
 			return;
 		}
 
@@ -101,23 +104,23 @@ class TestReportingMochaReporter extends Spec {
 		const name = makeDetailName(test);
 		const id = makeDetailId(file, name);
 
-		this._report
+		this.#report
 			.getDetail(id)
 			.incrementRetries()
 			.addDuration(duration);
 	}
 
-	_onTestEnd(test) {
+	#onTestEnd(test) {
 		const { file, _timeout } = test;
 
-		if (this._report.ignoreFilePath(file)) {
+		if (this.#report.ignoreFilePath(file)) {
 			return;
 		}
 
 		const { duration, state } = test;
 		const name = makeDetailName(test);
 		const id = makeDetailId(file, name);
-		const detail = this._report
+		const detail = this.#report
 			.getDetail(id)
 			.setTimeout(_timeout, { override: true });
 
@@ -137,7 +140,7 @@ class TestReportingMochaReporter extends Spec {
 		}
 	}
 
-	_onTestFail(test) {
+	#onTestFail(test) {
 		if (test.type !== 'hook') {
 			return;
 		}
@@ -150,13 +153,13 @@ class TestReportingMochaReporter extends Spec {
 
 		const { file, _timeout } = affectedTest;
 
-		if (!file || this._report.ignoreFilePath(file)) {
+		if (!file || this.#report.ignoreFilePath(file)) {
 			return;
 		}
 
 		const name = makeDetailName(affectedTest);
 		const id = makeDetailId(file, name);
-		const detail = this._report.getDetail(id);
+		const detail = this.#report.getDetail(id);
 
 		if (!detail.getStatus()) {
 			detail
@@ -169,9 +172,9 @@ class TestReportingMochaReporter extends Spec {
 		}
 	}
 
-	_onRunEnd(stats) {
+	#onRunEnd(stats) {
 		const { duration, failures } = stats;
-		const summary = this._report
+		const summary = this.#report
 			.getSummary()
 			.setDurationTotal(duration);
 
@@ -181,7 +184,7 @@ class TestReportingMochaReporter extends Spec {
 			summary.setFailed();
 		}
 
-		this._report
+		this.#report
 			.finalize()
 			.save();
 	}

--- a/src/reporters/playwright.js
+++ b/src/reporters/playwright.js
@@ -36,41 +36,46 @@ const getBrowser = (project) => {
 };
 
 export default class Reporter {
+	#hasTests;
+	#logger;
+	#options;
+	#report;
+
 	constructor(options = {}) {
-		this._options = options;
+		this.#options = options;
 	}
 
 	onBegin(_, suite) {
-		this._hasTests = suite.allTests().length !== 0;
+		this.#hasTests = suite.allTests().length !== 0;
 
-		if (!this._hasTests) {
+		if (!this.#hasTests) {
 			return;
 		}
 
-		this._logger = new PlaywrightLogger();
+		this.#logger = new PlaywrightLogger();
 
 		try {
-			this._report = new ReportBuilder('playwright', this._logger, this._options);
+			this.#report = new ReportBuilder('playwright', this.#logger, this.#options);
 		} catch ({ message }) {
-			this._logger.error('Failed to initialize D2L test report builder, report will not be generated');
-			this._logger.error(message);
+			this.#logger.error('Failed to initialize D2L test report builder, report will not be generated');
+			this.#logger.error(message);
 
 			return;
 		}
 
-		this._report
+		this.#report
 			.getSummary()
 			.addContext();
 	}
 
 	onTestEnd(test, result) {
-		if (!this._report || !this._hasTests) {
+		if (!this.#report || !this.#hasTests) {
 			return;
 		}
 
 		const { timeout, location: { file, line, column } } = test;
 
-		if (this._report.ignoreFilePath(file)) {
+		if (this.#report.ignoreFilePath(file)) {
 			return;
 		}
 
@@ -78,7 +83,7 @@ export default class Reporter {
 		const { startTime, retry, status, duration } = result;
 		const project = test.parent.project();
 		const name = makeTestName(test);
-		const detail = this._report
+		const detail = this.#report
 			.getDetail(id)
 			.setName(name)
 			.setLocationFile(file)
@@ -109,12 +114,12 @@ export default class Reporter {
 	}
 
 	onEnd(result) {
-		if (!this._report || !this._hasTests) {
+		if (!this.#report || !this.#hasTests) {
 			return;
 		}
 
 		const { startTime, duration, status } = result;
-		const summary = this._report
+		const summary = this.#report
 			.getSummary()
 			.setStarted(startTime)
 			.setDurationTotal(Math.round(duration));
@@ -125,14 +130,14 @@ export default class Reporter {
 			summary.setFailed();
 		}
 
-		this._report.finalize();
+		this.#report.finalize();
 	}
 
 	onExit() {
-		if (!this._report || !this._hasTests) {
+		if (!this.#report || !this.#hasTests) {
 			return;
 		}
 
-		this._report.save();
+		this.#report.save();
 	}
 }

--- a/src/reporters/webdriverio.cjs
+++ b/src/reporters/webdriverio.cjs
@@ -3,6 +3,16 @@ const { ReportBuilder } = require('../helpers/report-builder.cjs');
 const { escapeSpecialCharacters } = require('../helpers/strings.cjs');
 
 class WebdriverIO extends WDIOReporter {
+	#baseReportPath;
+	#logger;
+	#report;
+	#reportConfigurationPath;
+	#suiteStartTime;
+	#testFiles;
+	#testStartTimes;
+	#totalDuration;
+	#verbose;
+
 	constructor(options) {
 		super({
 			...options,
@@ -16,24 +26,24 @@ class WebdriverIO extends WDIOReporter {
 			location: (msg, loc) => console.log(`[D2L Reporter] ${msg}: ${loc}`)
 		};
 
-		this._baseReportPath = options.reportPath || './d2l-test-report.json';
-		this._reportConfigurationPath = options.reportConfigurationPath || './d2l-test-reporting.config.json';
-		this._verbose = options.verbose || false;
-		this._logger = logger;
-		this._report = null;
-		this._testStartTimes = new Map();
-		this._testFiles = new Map();
-		this._suiteStartTime = null;
-		this._totalDuration = 0;
+		this.#baseReportPath = options.reportPath || './d2l-test-report.json';
+		this.#reportConfigurationPath = options.reportConfigurationPath || './d2l-test-reporting.config.json';
+		this.#verbose = options.verbose || false;
+		this.#logger = logger;
+		this.#report = null;
+		this.#testStartTimes = new Map();
+		this.#testFiles = new Map();
+		this.#suiteStartTime = null;
+		this.#totalDuration = 0;
 	}
 
-	_getTestId(test) {
+	#getTestId(test) {
 		const file = test.file || test.parent || 'unknown';
 		const fullName = test.fullTitle || test.title || 'unknown-test';
 		return `${file}[${fullName}]`;
 	}
 
-	_getPlatformName() {
+	#getPlatformName() {
 		const capabilities = this.runnerStat?.capabilities;
 		if (!capabilities) return null;
 
@@ -41,8 +51,8 @@ class WebdriverIO extends WDIOReporter {
 		return platformName ? platformName.toLowerCase().trim() : null;
 	}
 
-	_makeTestName(test) {
-		const platform = this._getPlatformName();
+	#makeTestName(test) {
+		const platform = this.#getPlatformName();
 		let testName = (test.fullTitle || test.title || 'unknown-test');
 
 		testName = testName.split('.').map(part => escapeSpecialCharacters(part.trim())).join(' > ');
@@ -54,51 +64,51 @@ class WebdriverIO extends WDIOReporter {
 		const cid = runner.cid;
 
 		const path = require('path');
-		const dir = path.dirname(this._baseReportPath);
-		const ext = path.extname(this._baseReportPath);
-		const base = path.basename(this._baseReportPath, ext);
+		const dir = path.dirname(this.#baseReportPath);
+		const ext = path.extname(this.#baseReportPath);
+		const base = path.basename(this.#baseReportPath, ext);
 		const workerReportPath = path.join(dir, `${base}-${cid}${ext}`);
 
 		try {
-			this._report = new ReportBuilder('webdriverio', this._logger, {
+			this.#report = new ReportBuilder('webdriverio', this.#logger, {
 				reportPath: workerReportPath,
-				reportConfigurationPath: this._reportConfigurationPath,
-				verbose: this._verbose
+				reportConfigurationPath: this.#reportConfigurationPath,
+				verbose: this.#verbose
 			});
 			console.log('[D2L Reporter] Initialized successfully');
 		} catch (error) {
 			console.error('[D2L Reporter] Failed to initialize:', error.message);
-			this._report = null;
+			this.#report = null;
 			return;
 		}
 
-		this._suiteStartTime = new Date().toISOString();
+		this.#suiteStartTime = new Date().toISOString();
 
-		this._report
+		this.#report
 			.getSummary()
 			.addContext()
-			.setStarted(this._suiteStartTime);
+			.setStarted(this.#suiteStartTime);
 
 		console.log(`[D2L Reporter] Test run started (worker ${cid})`);
 	}
 
 	onTestStart(test) {
-		if (!this._report) return;
+		if (!this.#report) return;
 
 		const filePath = test.file || this.runnerStat?.specs?.[0] || 'unknown';
 
-		if (filePath !== 'unknown' && this._report.ignoreFilePath(filePath)) {
+		if (filePath !== 'unknown' && this.#report.ignoreFilePath(filePath)) {
 			return;
 		}
 
-		const testId = this._getTestId(test);
+		const testId = this.#getTestId(test);
 		const startTime = new Date().toISOString();
 
-		this._testStartTimes.set(testId, startTime);
-		this._testFiles.set(testId, filePath);
+		this.#testStartTimes.set(testId, startTime);
+		this.#testFiles.set(testId, filePath);
 
-		const testName = this._makeTestName(test);
-		const detail = this._report.getDetail(testId);
+		const testName = this.#makeTestName(test);
+		const detail = this.#report.getDetail(testId);
 		detail
 			.setName(testName)
 			.setLocationFile(filePath)
@@ -110,26 +120,26 @@ class WebdriverIO extends WDIOReporter {
 	}
 
 	onTestEnd(test) {
-		if (!this._report) return;
+		if (!this.#report) return;
 
-		const testId = this._getTestId(test);
-		let filePath = this._testFiles.get(testId);
+		const testId = this.#getTestId(test);
+		let filePath = this.#testFiles.get(testId);
 
 		if (!filePath) {
 			filePath = test.file || this.runnerStat?.specs?.[0] || 'unknown';
-			this._testFiles.set(testId, filePath);
+			this.#testFiles.set(testId, filePath);
 		}
 
-		if (filePath !== 'unknown' && this._report.ignoreFilePath(filePath)) {
+		if (filePath !== 'unknown' && this.#report.ignoreFilePath(filePath)) {
 			return;
 		}
 
-		const detail = this._report.getDetail(testId);
+		const detail = this.#report.getDetail(testId);
 
-		if (!this._testStartTimes.has(testId)) {
-			const testName = this._makeTestName(test);
+		if (!this.#testStartTimes.has(testId)) {
+			const testName = this.#makeTestName(test);
 			const startTime = new Date().toISOString();
-			this._testStartTimes.set(testId, startTime);
+			this.#testStartTimes.set(testId, startTime);
 
 			detail
 				.setName(testName)
@@ -145,7 +155,7 @@ class WebdriverIO extends WDIOReporter {
 			detail.setPassed();
 			if (test.duration) {
 				detail.addDuration(test.duration);
-				this._totalDuration += test.duration;
+				this.#totalDuration += test.duration;
 			}
 		} else if (test.state === 'skipped' || test.state === 'pending') {
 			detail.setSkipped();
@@ -154,36 +164,36 @@ class WebdriverIO extends WDIOReporter {
 			detail.setFailed();
 			if (test.duration) {
 				detail.addDuration(test.duration);
-				this._totalDuration += test.duration;
+				this.#totalDuration += test.duration;
 			}
 		}
 	}
 
 	onTestRetry(test) {
-		if (!this._report) return;
+		if (!this.#report) return;
 
-		const testId = this._getTestId(test);
-		const filePath = this._testFiles.get(testId) || test.file || this.runnerStat?.specs?.[0] || 'unknown';
+		const testId = this.#getTestId(test);
+		const filePath = this.#testFiles.get(testId) || test.file || this.runnerStat?.specs?.[0] || 'unknown';
 
-		if (filePath !== 'unknown' && this._report.ignoreFilePath(filePath)) {
+		if (filePath !== 'unknown' && this.#report.ignoreFilePath(filePath)) {
 			return;
 		}
-		const detail = this._report.getDetail(testId);
+		const detail = this.#report.getDetail(testId);
 
 		detail.incrementRetries();
 
 		if (test.duration) {
 			detail.addDuration(test.duration);
-			this._totalDuration += test.duration;
+			this.#totalDuration += test.duration;
 		}
 	}
 
 	onRunnerEnd(runner) {
-		if (!this._report) return;
+		if (!this.#report) return;
 
-		const summary = this._report.getSummary();
+		const summary = this.#report.getSummary();
 
-		summary.setDurationTotal(this._totalDuration);
+		summary.setDurationTotal(this.#totalDuration);
 
 		const stats = runner.failures > 0 ? 'failed' : 'passed';
 		if (stats === 'passed') {
@@ -192,7 +202,7 @@ class WebdriverIO extends WDIOReporter {
 			summary.setFailed();
 		}
 
-		this._report
+		this.#report
 			.finalize()
 			.save();
 


### PR DESCRIPTION
This change converts internal state and helper members across report builders, configuration helpers, report helpers, and reporters to private class fields so implementation details remain internal by default.

The goal is to reduce accidental coupling to internals and prevent function usage leakage by tightening encapsulation while preserving existing external behavior and report output contracts.

https://desire2learn.atlassian.net/browse/QE-2139