### PR TITLE
QE-2110: Add labeler config and label CI job

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -14,7 +14,7 @@
   description: New feature or request
   color: a2eeef
 - name: github-actions
-  description: Pull requests that update GitHub Actions workflows
+  description: Pull requests that update GitHub Actions code
   color: 000000
 - name: good first issue
   description: Good for newcomers


### PR DESCRIPTION
Adds a `.github/labeler.yml` and a `label` job to `ci.yml` so PRs are labeled automatically.