### PR TITLE
Move mocha `spec` pattern from `.mocharc.json` to `package.json`

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,4 +1,3 @@
 {
-  "spec": "test/unit/**/*.test.js",
   "reporter": "src/reporters/mocha.cjs"
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test:integration:playwright": "playwright test --config test/integration/data/configs/playwright.js || exit 0",
     "test:integration:web-test-runner": "wtr --config test/integration/data/configs/web-test-runner.js || exit 0",
     "test:integration:validate-reports": "mocha --reporter-options reportPath=./d2l-test-report-validation.json --spec test/integration/report-validation.test.js",
-    "test:unit": "mocha"
+    "test:unit": "mocha --spec \"test/unit/**/*.test.js\""
   },
   "dependencies": {
     "@wdio/reporter": "^9",


### PR DESCRIPTION
Move the mocha `spec` glob from `.mocharc.json` to the `test:unit` script in `package.json`. Using `--spec` on the CLI doesn't override the `spec` value in `.mocharc.json`, it appends to it, which causes the integration validation tests to also pick up unit test files.

QE-2045