### PR TITLE
fix: improve report configuration error messaging

### DIFF
--- a/schemas/report-configuration/v1.json
+++ b/schemas/report-configuration/v1.json
@@ -4,11 +4,20 @@
   "$ref": "#/$defs/taxonomyObject",
   "type": "object",
   "unevaluatedProperties": false,
+  "errorMessage": {
+    "type": "should be an object",
+    "unevaluatedProperties": "should only include supported report configuration properties"
+  },
   "properties": {
     "ignorePatterns": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
+      "errorMessage": {
+        "type": "should be an array of ignore patterns",
+        "minItems": "should contain at least one ignore pattern",
+        "uniqueItems": "should not contain duplicate ignore patterns"
+      },
       "items": {
         "$ref": "#/$defs/nonEmptyUnpaddedString"
       }
@@ -17,11 +26,24 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
+      "errorMessage": {
+        "type": "should be an array of override objects",
+        "minItems": "should contain at least one override",
+        "uniqueItems": "should not contain duplicate overrides"
+      },
       "items": {
         "type": "object",
         "unevaluatedProperties": false,
         "minProperties": 2,
         "$ref": "#/$defs/taxonomyObject",
+        "errorMessage": {
+          "type": "should be an object",
+          "minProperties": "should include pattern and at least one taxonomy override",
+          "required": {
+            "pattern": "should include pattern and at least one taxonomy override"
+          },
+          "unevaluatedProperties": "should only include supported override properties"
+        },
         "properties": {
           "pattern": {
             "$ref": "#/$defs/nonEmptyUnpaddedString"
@@ -35,6 +57,9 @@
   },
   "allOf": [
     {
+      "errorMessage": {
+        "if": "should include type in each override when top-level type is null"
+      },
       "if": {
         "properties": {
           "type": {
@@ -53,6 +78,11 @@
                   "$ref": "#/$defs/taxonomyObject/properties/type"
                 }
               },
+              "errorMessage": {
+                "required": {
+                  "type": "should include type in each override when top-level type is null"
+                }
+              },
               "required": [
                 "type"
               ]
@@ -62,6 +92,9 @@
       }
     },
     {
+      "errorMessage": {
+        "if": "should include tool in each override when top-level tool is null"
+      },
       "if": {
         "properties": {
           "tool": {
@@ -80,6 +113,11 @@
                   "$ref": "#/$defs/taxonomyObject/properties/tool"
                 }
               },
+              "errorMessage": {
+                "required": {
+                  "tool": "should include tool in each override when top-level tool is null"
+                }
+              },
               "required": [
                 "tool"
               ]
@@ -89,6 +127,9 @@
       }
     },
     {
+      "errorMessage": {
+        "if": "should include experience in each override when top-level experience is null"
+      },
       "if": {
         "properties": {
           "experience": {
@@ -107,6 +148,11 @@
                   "$ref": "#/$defs/taxonomyObject/properties/experience"
                 }
               },
+              "errorMessage": {
+                "required": {
+                  "experience": "should include experience in each override when top-level experience is null"
+                }
+              },
               "required": [
                 "experience"
               ]
@@ -116,6 +162,9 @@
       }
     },
     {
+      "errorMessage": {
+        "if": "should include overrides when all taxonomy properties are null"
+      },
       "if": {
         "properties": {
           "type": {
@@ -130,6 +179,11 @@
         }
       },
       "then": {
+        "errorMessage": {
+          "required": {
+            "overrides": "should include overrides when all taxonomy properties are null"
+          }
+        },
         "required": [
           "overrides"
         ]
@@ -140,7 +194,12 @@
     "nonEmptyUnpaddedString": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^(?!\\s).+(?<!\\s)$"
+      "pattern": "^(?!\\s).+(?<!\\s)$",
+      "errorMessage": {
+        "type": "should be a string",
+        "minLength": "should be non-empty without leading or trailing whitespace",
+        "pattern": "should be non-empty without leading or trailing whitespace"
+      }
     },
     "taxonomyObject": {
       "type": "object",

--- a/schemas/report-configuration/v2.json
+++ b/schemas/report-configuration/v2.json
@@ -4,11 +4,20 @@
   "$ref": "#/$defs/taxonomyObject",
   "type": "object",
   "unevaluatedProperties": false,
+  "errorMessage": {
+    "type": "should be an object",
+    "unevaluatedProperties": "should only include supported report configuration properties"
+  },
   "properties": {
     "ignorePatterns": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
+      "errorMessage": {
+        "type": "should be an array of ignore patterns",
+        "minItems": "should contain at least one ignore pattern",
+        "uniqueItems": "should not contain duplicate ignore patterns"
+      },
       "items": {
         "$ref": "#/$defs/nonEmptyUnpaddedString"
       }
@@ -17,11 +26,24 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
+      "errorMessage": {
+        "type": "should be an array of override objects",
+        "minItems": "should contain at least one override",
+        "uniqueItems": "should not contain duplicate overrides"
+      },
       "items": {
         "type": "object",
         "unevaluatedProperties": false,
         "minProperties": 2,
         "$ref": "#/$defs/taxonomyObject",
+        "errorMessage": {
+          "type": "should be an object",
+          "minProperties": "should include pattern and at least one taxonomy override",
+          "required": {
+            "pattern": "should include pattern and at least one taxonomy override"
+          },
+          "unevaluatedProperties": "should only include supported override properties"
+        },
         "properties": {
           "pattern": {
             "$ref": "#/$defs/nonEmptyUnpaddedString"
@@ -35,6 +57,9 @@
   },
   "allOf": [
     {
+      "errorMessage": {
+        "if": "should include type in each override when top-level type is null"
+      },
       "if": {
         "properties": {
           "type": {
@@ -53,6 +78,11 @@
                   "$ref": "#/$defs/taxonomyObject/properties/type"
                 }
               },
+              "errorMessage": {
+                "required": {
+                  "type": "should include type in each override when top-level type is null"
+                }
+              },
               "required": [
                 "type"
               ]
@@ -62,6 +92,9 @@
       }
     },
     {
+      "errorMessage": {
+        "if": "should include tool in each override when top-level tool is null"
+      },
       "if": {
         "properties": {
           "tool": {
@@ -80,6 +113,11 @@
                   "$ref": "#/$defs/taxonomyObject/properties/tool"
                 }
               },
+              "errorMessage": {
+                "required": {
+                  "tool": "should include tool in each override when top-level tool is null"
+                }
+              },
               "required": [
                 "tool"
               ]
@@ -89,6 +127,9 @@
       }
     },
     {
+      "errorMessage": {
+        "if": "should include overrides when all taxonomy properties are null"
+      },
       "if": {
         "properties": {
           "type": {
@@ -100,6 +141,11 @@
         }
       },
       "then": {
+        "errorMessage": {
+          "required": {
+            "overrides": "should include overrides when all taxonomy properties are null"
+          }
+        },
         "required": [
           "overrides"
         ]
@@ -110,7 +156,12 @@
     "nonEmptyUnpaddedString": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^(?!\\s).+(?<!\\s)$"
+      "pattern": "^(?!\\s).+(?<!\\s)$",
+      "errorMessage": {
+        "type": "should be a string",
+        "minLength": "should be non-empty without leading or trailing whitespace",
+        "pattern": "should be non-empty without leading or trailing whitespace"
+      }
     },
     "taxonomyObject": {
       "type": "object",

--- a/src/helpers/report-configuration.cjs
+++ b/src/helpers/report-configuration.cjs
@@ -30,12 +30,6 @@ const upgradeReportConfigurationV1ToV2 = (configuration, logger) => {
 				logger.warning(`Report configuration override for pattern '${override.pattern}' has field 'experience' which is no longer supported and will be ignored`);
 			}
 
-			if (Object.keys(overrideRest).length < 2) {
-				logger.warning(`Report configuration override for pattern '${override.pattern}' has no remaining fields after upgrade and will be dropped`);
-
-				continue;
-			}
-
 			upgradedOverrides.push(overrideRest);
 		}
 

--- a/src/helpers/schema.cjs
+++ b/src/helpers/schema.cjs
@@ -47,7 +47,29 @@ const validateReportV3ContextAjv = ajv.getSchema('/test-reporting/schemas/report
 const validateReportV1Ajv = ajv.getSchema('/test-reporting/schemas/report/v1.json');
 const validateReportV2Ajv = ajv.getSchema('/test-reporting/schemas/report/v2.json');
 const validateReportV3Ajv = ajv.getSchema('/test-reporting/schemas/report/v3.json');
-const formatErrorAjv = ajv.errorsText;
+
+const decodeInstancePathAjv = (instancePath = '') => {
+	if (!instancePath) {
+		return '';
+	}
+
+	return instancePath
+		.replace(/\//g, '.')
+		.replace(/~1/g, '/')
+		.replace(/~0/g, '~');
+};
+
+const formatErrorAjv = (errors, options = {}) => {
+	const { dataVar = 'data' } = options;
+	const messages = [...new Set((errors ?? []).map(({ instancePath, message }) => {
+		const decodedPath = decodeInstancePathAjv(instancePath);
+
+		return `[${dataVar}]${decodedPath}: ${message}`;
+	}))];
+
+	return messages.sort().reverse().join('\n');
+};
+
 const { properties: latestReportSchemaProperties } = latestReportSchema;
 const { version: { const: latestReportVersion } } = latestReportSchemaProperties;
 const { details: { items: { properties: { browser: { enum: latestSupportedBrowsers } } } } } = latestReportSchemaProperties;

--- a/src/reporters/mocha.cjs
+++ b/src/reporters/mocha.cjs
@@ -14,7 +14,14 @@ const {
 } = constants;
 
 class MochaLogger {
-	info(message) { consoleLog(`  ${message}`); }
+	info(message) {
+		const lines = `${message}`.split(/\r?\n/u);
+
+		for (const line of lines) {
+			consoleLog(`  ${line}`);
+		}
+	}
+
 	warning(message) { this.info(color('bright yellow', message)); }
 	error(message) { this.info(color('fail', message)); }
 	location(message, location) { this.info(`${message}: ${color('pending', location)}`); }
@@ -48,8 +55,13 @@ class TestReportingMochaReporter extends Spec {
 
 			this.#report = report;
 		} catch ({ message }) {
-			this.#logger.error('Failed to initialize D2L test report builder, report will not be generated');
+			this.#logger.error('\nFailed to initialize D2L test report builder, report will not be generated\n');
 			this.#logger.error(message);
+
+			runner.once(
+				EVENT_RUN_END,
+				() => this.#logger.error('\nD2L test report was not generated due to initialization failure')
+			);
 
 			return;
 		}

--- a/src/reporters/playwright.js
+++ b/src/reporters/playwright.js
@@ -9,7 +9,14 @@ const { ReportBuilder } = require('../helpers/report-builder.cjs');
 const { cyan, red, yellow } = colors;
 
 class PlaywrightLogger {
-	info(message) { console.log(`\n${message}\n`); }
+	info(message) {
+		const lines = `${message}`.split(/\r?\n/u);
+
+		for (const line of lines) {
+			console.log(`\n${line}\n`);
+		}
+	}
+
 	warning(message) { this.info(yellow(message)); }
 	error(message) { this.info(red(message)); }
 	location(message, location) { this.info(`${message}: ${cyan(location)}`); }
@@ -59,6 +66,7 @@ export default class Reporter {
 		} catch ({ message }) {
 			this.#logger.error('Failed to initialize D2L test report builder, report will not be generated');
 			this.#logger.error(message);
+			this.#report = null;
 
 			return;
 		}
@@ -135,6 +143,10 @@ export default class Reporter {
 
 	onExit() {
 		if (!this.#report || !this.#hasTests) {
+			if (this.#hasTests && !this.#report) {
+				this.#logger.error('D2L test report was not generated due to initialization failure');
+			}
+
 			return;
 		}
 

--- a/src/reporters/web-test-runner.js
+++ b/src/reporters/web-test-runner.js
@@ -6,7 +6,14 @@ import { SESSION_STATUS } from '@web/test-runner-core';
 const { yellow, red, cyan, bold } = chalk;
 
 class WebTestRunnerLogger {
-	info(message) { console.log(`\n${message}\n`); }
+	info(message) {
+		const lines = `${message}`.split(/\r?\n/u);
+
+		for (const line of lines) {
+			console.log(`\n${line}\n`);
+		}
+	}
+
 	warning(message) { this.info(yellow(bold(message))); }
 	error(message) { this.info(red(bold(message))); }
 	location(message, location) { this.info(`${message}: ${cyan(bold(location))}`); }
@@ -24,11 +31,6 @@ const makeDetailId = (sessionId, file, name) => {
 	return `${sessionId}/${file}/${name}`;
 };
 
-const nullReporter = {
-	start() {},
-	stop() {}
-};
-
 export function reporter(options = {}) {
 	let overallStarted;
 	let testConfig;
@@ -42,7 +44,12 @@ export function reporter(options = {}) {
 		logger.error('Failed to initialize D2L test report builder, report will not be generated');
 		logger.error(message);
 
-		return nullReporter;
+		return {
+			start() {},
+			stop() {
+				logger.error('D2L test report was not generated due to initialization failure');
+			}
+		};
 	}
 
 	const summary = report

--- a/src/reporters/webdriverio.cjs
+++ b/src/reporters/webdriverio.cjs
@@ -20,7 +20,13 @@ class WebdriverIO extends WDIOReporter {
 		});
 
 		const logger = {
-			info: (msg) => console.log(`[D2L Reporter] ${msg}`),
+			info: (msg) => {
+				const lines = `${msg}`.split(/\r?\n/u);
+
+				for (const line of lines) {
+					console.log(`[D2L Reporter] ${line}`);
+				}
+			},
 			warning: (msg) => console.warn(`[D2L Reporter] ${msg}`),
 			error: (msg) => console.error(`[D2L Reporter] ${msg}`),
 			location: (msg, loc) => console.log(`[D2L Reporter] ${msg}: ${loc}`)
@@ -189,7 +195,11 @@ class WebdriverIO extends WDIOReporter {
 	}
 
 	onRunnerEnd(runner) {
-		if (!this.#report) return;
+		if (!this.#report) {
+			this.#logger.error('D2L test report was not generated due to initialization failure');
+
+			return;
+		}
 
 		const summary = this.#report.getSummary();
 

--- a/test/unit/report-configuration.test.js
+++ b/test/unit/report-configuration.test.js
@@ -90,30 +90,28 @@ describe('report configuration', () => {
 				expect(warningMessages().some(msg => msg.includes('**/special.test.js') && msg.includes('\'experience\''))).to.be.true;
 			});
 
-			it('drops override with only pattern', () => {
-				const config = loadConfig({
+			it('throws for override with only pattern after experience removed', () => {
+				expect(() => loadConfig({
 					type: 'integration',
 					tool: 'Test Reporting',
 					overrides: [{
 						pattern: '**/special.test.js',
 						experience: 'Special Experience'
 					}]
-				});
-
-				expect(config.toJSON()).to.not.have.property('overrides');
+				})).to.throw(/report configuration/);
 			});
 
-			it('warns when override dropped', () => {
-				loadConfig({
+			it('warns before throwing when experience stripped leaves empty override', () => {
+				expect(() => loadConfig({
 					type: 'integration',
 					tool: 'Test Reporting',
 					overrides: [{
 						pattern: '**/special.test.js',
 						experience: 'Special Experience'
 					}]
-				});
+				})).to.throw();
 
-				expect(warningMessages().some(msg => msg.includes('**/special.test.js') && msg.includes('will be dropped'))).to.be.true;
+				expect(warningMessages().some(msg => msg.includes('**/special.test.js') && msg.includes('\'experience\''))).to.be.true;
 			});
 		});
 


### PR DESCRIPTION
Add user-friendly `errorMessage` entries to report configuration schemas, rewrite the AJV error formatter to use `instancePath` for clearer output, fix the v1-to-v2 upgrade to not silently drop overrides when experience is removed, and improve reporter error UX (multi-line indentation, end-of-run failure messages) across all four reporters.

We can iterate on error messaging as we find better phrasing.

### Before

<img width="1056" height="86" alt="image" src="https://github.com/user-attachments/assets/86479d53-29ff-4d01-be91-8de43497d5cb" />

### After

<img width="1068" height="182" alt="image" src="https://github.com/user-attachments/assets/21641e5e-f4f8-4169-8dcb-3c428a6de85f" />

<img width="562" height="87" alt="image" src="https://github.com/user-attachments/assets/6391a3bc-0946-466b-8036-96b4f883c93b" />

QE-2045