### PR TITLE
fix: capture Date at module load so reporter timestamps survive sinon fake timers and other global timer mutations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
       - dependency-name: '*'
         update-types: ['version-update:semver-patch']
       - dependency-name: eslint
-        versions: '>=10'
+        versions: '>= 10'
     groups:
       eslint:
         dependency-type: development

--- a/docs/report-builder.md
+++ b/docs/report-builder.md
@@ -53,7 +53,8 @@ report.getSummary().setStarted(time).setPassed();
 > for actual hook names and parameters.
 
 ```js
-const { ReportBuilder } = require('d2l-test-reporting/helpers/report-builder.cjs');
+const { ReportBuilder } = require('../helpers/report-builder.cjs');
+const { getNowISOString } = require('../helpers/system.cjs');
 
 class CustomReporter {
   constructor(options = {}) {
@@ -83,7 +84,7 @@ class CustomReporter {
     this._report.getDetail(testId)
       .setName(test.name)
       .setLocationFile(test.file)
-      .setStarted(new Date().toISOString())
+      .setStarted(getNowISOString())
       .setTimeout(test.timeout);
   }
 
@@ -225,7 +226,9 @@ report.finalize().save();
 * Call `finalize()` before `save()`
 * Check `ignoreFilePath()` before processing each test
 * Use a consistent test ID format throughout
-* Use ISO 8601 timestamps: `new Date().toISOString()`
+* Use `getNowISOString()` from `helpers/system.cjs` for ISO 8601 timestamps so
+  reports are unaffected by anything in user tests that mutates time
+  (e.g. `sinon.useFakeTimers`)
 * Wrap `new ReportBuilder()` in try-catch
 
 ## See Also

--- a/src/helpers/system.cjs
+++ b/src/helpers/system.cjs
@@ -3,6 +3,18 @@ const { relative, sep: platformSeparator } = require('node:path');
 const { join } = require('node:path/posix');
 const { fileURLToPath } = require('node:url');
 
+// Captured at module load so reporter timestamps survive sinon.useFakeTimers,
+// which reassigns globalThis.Date but does not mutate the original constructor
+const RealDate = Date;
+
+const getNow = () => {
+	return new RealDate();
+};
+
+const getNowISOString = () => {
+	return new RealDate().toISOString();
+};
+
 const getOperatingSystemType = () => {
 	switch (os.type()) {
 		case 'Linux':
@@ -27,4 +39,9 @@ const makeRelativeFilePath = (filePath) => {
 	return join(...pathParts);
 };
 
-module.exports = { getOperatingSystemType, makeRelativeFilePath };
+module.exports = {
+	getNow,
+	getNowISOString,
+	getOperatingSystemType,
+	makeRelativeFilePath
+};

--- a/src/reporters/mocha.cjs
+++ b/src/reporters/mocha.cjs
@@ -1,6 +1,7 @@
 const { reporters: { Base, Spec }, Runner: { constants } } = require('mocha');
 const { escapeSpecialCharacters } = require('../helpers/strings.cjs');
 const { ReportBuilder } = require('../helpers/report-builder.cjs');
+const { getNowISOString } = require('../helpers/system.cjs');
 
 const { consoleLog, color } = Base;
 const {
@@ -101,7 +102,7 @@ class TestReportingMochaReporter extends Spec {
 			.getDetail(id)
 			.setName(name)
 			.setLocationFile(file)
-			.setStarted((new Date()).toISOString())
+			.setStarted(getNowISOString())
 			.setTimeout(_timeout); // using internal property, not ideal
 	}
 
@@ -177,7 +178,7 @@ class TestReportingMochaReporter extends Spec {
 			detail
 				.setName(name)
 				.setLocationFile(file)
-				.setStarted((new Date()).toISOString())
+				.setStarted(getNowISOString())
 				.setTimeout(_timeout)
 				.addDuration(0)
 				.setFailed();

--- a/src/reporters/web-test-runner.js
+++ b/src/reporters/web-test-runner.js
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import { escapeSpecialCharacters } from '../helpers/strings.cjs';
 import { ReportBuilder } from '../helpers/report-builder.cjs';
+import { getNow, getNowISOString } from '../helpers/system.cjs';
 import { SESSION_STATUS } from '@web/test-runner-core';
 
 const { yellow, red, cyan, bold } = chalk;
@@ -58,7 +59,7 @@ export function reporter(options = {}) {
 
 	const collectTests = (session, prefix, tests) => {
 		const { id: sessionId, browser: { name: browserName }, testFile } = session;
-		const started = sessionStarts.get(sessionId) ?? (new Date()).toISOString();
+		const started = sessionStarts.get(sessionId) ?? getNowISOString();
 
 		if (report.ignoreFilePath(testFile)) {
 			return;
@@ -149,7 +150,7 @@ export function reporter(options = {}) {
 			}
 
 			const started = new Date(overallStarted);
-			const ended = new Date();
+			const ended = getNow();
 			const duration = Math.abs(ended - started);
 
 			summary.setDurationTotal(duration);
@@ -166,14 +167,14 @@ export function reporter(options = {}) {
 					case SESSION_STATUS.SCHEDULED:
 					case SESSION_STATUS.INITIALIZING:
 					case SESSION_STATUS.TEST_STARTED:
-						sessionStarts.set(id, (new Date()).toISOString());
+						sessionStarts.set(id, getNowISOString());
 
 						break;
 					case SESSION_STATUS.TEST_FINISHED:
 					case SESSION_STATUS.FINISHED:
 					default:
 						if (!sessionStarts.has(id)) {
-							sessionStarts.set(id, (new Date()).toISOString());
+							sessionStarts.set(id, getNowISOString());
 						}
 
 						break;

--- a/src/reporters/webdriverio.cjs
+++ b/src/reporters/webdriverio.cjs
@@ -1,6 +1,7 @@
 const WDIOReporter = require('@wdio/reporter').default;
 const { ReportBuilder } = require('../helpers/report-builder.cjs');
 const { escapeSpecialCharacters } = require('../helpers/strings.cjs');
+const { getNowISOString } = require('../helpers/system.cjs');
 
 class WebdriverIO extends WDIOReporter {
 	#baseReportPath;
@@ -88,7 +89,7 @@ class WebdriverIO extends WDIOReporter {
 			return;
 		}
 
-		this.#suiteStartTime = new Date().toISOString();
+		this.#suiteStartTime = getNowISOString();
 
 		this.#report
 			.getSummary()
@@ -108,7 +109,7 @@ class WebdriverIO extends WDIOReporter {
 		}
 
 		const testId = this.#getTestId(test);
-		const startTime = new Date().toISOString();
+		const startTime = getNowISOString();
 
 		this.#testStartTimes.set(testId, startTime);
 		this.#testFiles.set(testId, filePath);
@@ -144,7 +145,7 @@ class WebdriverIO extends WDIOReporter {
 
 		if (!this.#testStartTimes.has(testId)) {
 			const testName = this.#makeTestName(test);
-			const startTime = new Date().toISOString();
+			const startTime = getNowISOString();
 			this.#testStartTimes.set(testId, startTime);
 
 			detail

--- a/test/integration/data/tests/mocha/fake-timers.test.js
+++ b/test/integration/data/tests/mocha/fake-timers.test.js
@@ -1,0 +1,25 @@
+import { createSandbox } from 'sinon';
+
+const realSetTimeout = setTimeout;
+
+const delay = (ms = 50) => {
+	return new Promise(resolve => realSetTimeout(resolve, ms));
+};
+
+const fakeNow = 1234567890;
+
+describe('fake timers', () => {
+	let sandbox;
+
+	before(() => {
+		sandbox = createSandbox();
+
+		sandbox.useFakeTimers(fakeNow);
+	});
+
+	after(() => sandbox.restore());
+
+	it('passed', async() => { await delay(); });
+
+	it('failed', () => { throw new Error('fail'); });
+});

--- a/test/integration/data/validation/test-report-mocha.js
+++ b/test/integration/data/validation/test-report-mocha.js
@@ -5,7 +5,7 @@ export const testReportLatestPartial = {
 	summary: {
 		status: 'failed',
 		framework: 'mocha',
-		count: { passed: 9, failed: 6, skipped: 2, flaky: 2 }
+		count: { passed: 10, failed: 7, skipped: 2, flaky: 2 }
 	},
 	details: [{
 		name: 'custom timeout > suite level timeout',
@@ -21,6 +21,20 @@ export const testReportLatestPartial = {
 		configuration: { timeout: 10000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
+	}, {
+		name: 'fake timers > passed',
+		status: 'passed',
+		location: { file: 'test/integration/data/tests/mocha/fake-timers.test.js' },
+		configuration: { timeout: 2000 },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 0
+	}, {
+		name: 'fake timers > failed',
+		status: 'failed',
+		location: { file: 'test/integration/data/tests/mocha/fake-timers.test.js' },
+		configuration: { timeout: 2000 },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 3
 	}, {
 		name: 'hook failures > before all failure > test with before all failure',
 		status: 'failed',

--- a/test/unit/system.test.js
+++ b/test/unit/system.test.js
@@ -1,4 +1,4 @@
-import { getOperatingSystemType, makeRelativeFilePath } from '../../src/helpers/system.cjs';
+import { getNow, getNowISOString, getOperatingSystemType, makeRelativeFilePath } from '../../src/helpers/system.cjs';
 import { createSandbox } from 'sinon';
 import { expect } from 'chai';
 import os from 'node:os';
@@ -48,6 +48,20 @@ describe('system', () => {
 			const fileUrl = new URL(`file://${process.cwd().replace(/\\/g, '/')}/src/file.js`).href;
 
 			expect(makeRelativeFilePath(fileUrl)).to.eq('src/file.js');
+		});
+	});
+
+	describe('now', () => {
+		const fakeNow = 1234567890;
+
+		beforeEach(() => sandbox.useFakeTimers(fakeNow));
+
+		it('date', () => {
+			expect(getNow().getTime()).to.be.greaterThan(fakeNow);
+		});
+
+		it('iso string', () => {
+			expect(Date.parse(getNowISOString())).to.be.greaterThan(fakeNow);
 		});
 	});
 });


### PR DESCRIPTION
Reporter timestamps were captured via `new Date()`, so any user test that called `sinon.useFakeTimers` produced reports with fake timestamps. A new `getNow` / `getNowISOString` helper in `system.cjs` captures `Date` at module load (before any user test runs) and every reporter wall-clock call now routes through it.

This only adds an integration test for mocha right now as I'm going to rework the other framework tests to be more functional based like I have with mocha. I'll add the fake now test at that point.

https://desire2learn.atlassian.net/browse/QE-2045