### PR TITLE
Restore WebdriverIO integration tests

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,10 +1,10 @@
 {
   "all": true,
   "check-coverage": true,
-  "statements": 70,
-  "branches": 70,
+  "statements": 80,
+  "branches": 75,
   "functions": 85,
-  "lines": 70,
+  "lines": 80,
   "include": [
     "src/**/*.{js,cjs}"
   ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,10 @@ jobs:
         run: npm ci
       - name: Install dependencies (Playwright)
         run: npx playwright install --with-deps
+      - name: Setup dependencies (WebdriverIO)
+        run: |
+          /usr/bin/chromedriver --version
+          echo "CHROMEDRIVER_PATH=/usr/bin/chromedriver" >> $GITHUB_ENV
       - name: Run tests
         id: tests
         run: npm run test:all

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:integration:mocha": "mocha --config test/integration/data/configs/mocha.cjs || exit 0",
     "test:integration:playwright": "playwright test --config test/integration/data/configs/playwright.js || exit 0",
     "test:integration:web-test-runner": "wtr --config test/integration/data/configs/web-test-runner.js || exit 0",
+    "test:integration:webdriverio": "wdio run test/integration/data/configs/webdriverio.cjs || exit 0",
     "test:integration:validate-reports": "mocha --reporter-options reportPath=./d2l-test-report-validation.json --spec test/integration/report-validation.test.js",
     "test:unit": "mocha --spec \"test/unit/**/*.test.js\""
   },

--- a/test/integration/report-validation.test.js
+++ b/test/integration/report-validation.test.js
@@ -9,6 +9,7 @@ import { Report } from '../../src/helpers/report.cjs';
 import { testReportLatestPartial as testReportLatestPartialMocha } from './data/validation/test-report-mocha.js';
 import { testReportLatestPartial as testReportLatestPartialPlaywright } from './data/validation/test-report-playwright.js';
 import { testReportLatestPartial as testReportLatestPartialWebTestRunner } from './data/validation/test-report-web-test-runner.js';
+import { testReportLatestPartial as testReportLatestPartialWebdriverIO } from './data/validation/test-report-webdriverio.js';
 import yn from 'yn';
 
 use(chaiSubset);
@@ -43,6 +44,11 @@ const reportTests = [{
 	version: latestReportVersion,
 	path: './d2l-test-report-web-test-runner.json',
 	expected: testReportLatestPartialWebTestRunner
+}, {
+	name: 'webdriverio',
+	version: latestReportVersion,
+	path: './d2l-test-report-webdriverio.json',
+	expected: testReportLatestPartialWebdriverIO
 }];
 const results = reportTests.reduce((acc, cur) => {
 	acc[cur.name] = {


### PR DESCRIPTION
Reverts #858 by restoring `test:integration:webdriverio` in `package.json` and the `webdriverio` entry in `report-validation.test.js`. The CI breakage was caused by `@wdio/utils` failing to extract Chromedriver via `@puppeteer/browsers` (only `LICENSE` and `THIRD_PARTY_NOTICES` end up unpacked), which silently aborted the launcher with SIGINT before any test ran. The Test job now points WDIO at the runner's pre-installed `/usr/bin/chromedriver` via `CHROMEDRIVER_PATH`.

https://desire2learn.atlassian.net/browse/QE-2205