### PR TITLE
fix: normalize leading ./ in report config glob patterns

### DIFF
--- a/src/helpers/report-configuration.cjs
+++ b/src/helpers/report-configuration.cjs
@@ -12,6 +12,8 @@ const defaultLogger = {
 	warning: (message) => console.warn(message)
 };
 
+const normalizePattern = (pattern) => pattern.replace(/^(?:\.\/)+/, '');
+
 const upgradeReportConfigurationV1ToV2 = (configuration, logger) => {
 	const { experience, overrides, ...rest } = configuration;
 	const upgraded = { ...rest };
@@ -114,7 +116,7 @@ class ReportConfiguration {
 				tool: overriddenTool
 			} = override;
 
-			if (minimatch(filePath, pattern)) {
+			if (minimatch(filePath, normalizePattern(pattern))) {
 				metadata.type = overriddenType?.toLowerCase();
 				metadata.tool = overriddenTool;
 
@@ -145,7 +147,7 @@ class ReportConfiguration {
 		const { ignorePatterns } = this.#reportConfiguration;
 
 		for (const ignorePattern of ignorePatterns ?? []) {
-			if (minimatch(filePath, ignorePattern)) {
+			if (minimatch(filePath, normalizePattern(ignorePattern))) {
 				return true;
 			}
 		}

--- a/test/integration/data/d2l-test-reporting.config.json
+++ b/test/integration/data/d2l-test-reporting.config.json
@@ -2,7 +2,7 @@
   "type": "integration",
   "tool": "Test Reporting",
   "ignorePatterns": [
-    "**/tests/mocha/ignored.test.js",
+    "./test/integration/data/tests/mocha/ignored.test.js",
     "**/tests/playwright/ignored.test.js",
     "**/tests/playwright/setup.js",
     "**/tests/playwright/teardown.js",
@@ -15,7 +15,7 @@
       "tool": "Mocha 1 Test Reporting"
     },
     {
-      "pattern": "**/tests/mocha/hook-failures.test.js",
+      "pattern": "./test/integration/data/tests/mocha/hook-failures.test.js",
       "type": "ui",
       "tool": "Mocha Hook Failures Test Reporting"
     },

--- a/test/unit/report-configuration.test.js
+++ b/test/unit/report-configuration.test.js
@@ -201,6 +201,23 @@ describe('report configuration', () => {
 			});
 		});
 
+		it('normalizes leading ./', () => {
+			const config = loadConfig({
+				type: 'integration',
+				tool: 'Default Tool',
+				overrides: [{
+					pattern: './test/**/*.test.js',
+					type: 'UI',
+					tool: 'Special Tool'
+				}]
+			});
+
+			expect(config.getTaxonomy('test/special.test.js')).to.deep.equal({
+				type: 'ui',
+				tool: 'Special Tool'
+			});
+		});
+
 		it('omits experience', () => {
 			const config = loadConfig({
 				type: 'integration',
@@ -251,6 +268,16 @@ describe('report configuration', () => {
 			});
 
 			expect(config.ignoreFilePath('test/example.test.js')).to.be.false;
+		});
+
+		it('normalizes leading ./', () => {
+			const config = loadConfig({
+				type: 'integration',
+				tool: 'Test Reporting',
+				ignorePatterns: ['./test/ignored/**']
+			});
+
+			expect(config.ignoreFilePath('test/ignored/example.test.js')).to.be.true;
 		});
 	});
 });


### PR DESCRIPTION
Normalizes a leading `./` on `overrides[].pattern` and `ignorePatterns[]` in the report configuration so equivalent globs (e.g. `./test/**/*.test.js` and `test/**/*.test.js`) are treated the same when matching against file paths.

https://desire2learn.atlassian.net/browse/QE-2208