### PR TITLE
feat: add webdriverio browser support

### DIFF
--- a/src/reporters/playwright.js
+++ b/src/reporters/playwright.js
@@ -31,12 +31,16 @@ const makeTestName = (test) => {
 		.join(' > ');
 };
 
-const getBrowser = (project) => {
+const getBrowser = (project, logger) => {
 	const { name, use: { browserName, defaultBrowserType } = {} } = project;
 	const browser = (browserName ?? defaultBrowserType ?? name)?.trim().toLowerCase();
 
 	if (ReportBuilder.SupportedBrowsers.includes(browser)) {
 		return browser;
+	}
+
+	if (browser) {
+		logger.warning(`Unsupported browser '${browser}', omitting from test report detail`);
 	}
 
 	return null;
@@ -106,7 +110,7 @@ export default class Reporter {
 			detail.incrementRetries();
 		}
 
-		const browser = getBrowser(project);
+		const browser = getBrowser(project, this.#logger);
 
 		if (browser) {
 			detail.setBrowser(browser);

--- a/src/reporters/webdriverio.cjs
+++ b/src/reporters/webdriverio.cjs
@@ -72,6 +72,26 @@ class WebdriverIO extends WDIOReporter {
 		return platformName ? platformName.toLowerCase().trim() : null;
 	}
 
+	#getBrowserName() {
+		const capabilities = this.runnerStat?.capabilities;
+
+		if (!capabilities) {
+			return null;
+		}
+
+		const browser = capabilities.browserName?.toLowerCase().trim();
+
+		if (browser && ReportBuilder.SupportedBrowsers.includes(browser)) {
+			return browser;
+		}
+
+		if (browser) {
+			this.#logger.warning(`Unsupported browser '${browser}', omitting from test report detail`);
+		}
+
+		return null;
+	}
+
 	#makeTestName(fullTitle) {
 		const platform = this.#getPlatformName();
 		const name = fullTitle
@@ -84,11 +104,16 @@ class WebdriverIO extends WDIOReporter {
 
 	#openDetail(suite, test) {
 		const id = makeDetailId(suite.file, test.fullTitle);
+		const browser = this.#getBrowserName();
 		const detail = this.#report
 			.getDetail(id)
 			.setName(this.#makeTestName(test.fullTitle))
 			.setLocationFile(suite.file)
 			.setStarted(getNowISOString());
+
+		if (browser) {
+			detail.setBrowser(browser);
+		}
 
 		if (test.timeout) {
 			detail.setTimeout(test.timeout);
@@ -159,6 +184,7 @@ class WebdriverIO extends WDIOReporter {
 			);
 
 			if (failedBeforeHooks.length !== 0) {
+				const browser = this.#getBrowserName();
 				const tests = suite.tests?.length ? suite.tests : failedBeforeHooks
 					.filter(hook => hook.currentTest)
 					.map(hook => ({
@@ -176,6 +202,10 @@ class WebdriverIO extends WDIOReporter {
 							.setStarted(getNowISOString())
 							.addDuration(0)
 							.setFailed();
+
+						if (browser) {
+							detail.setBrowser(browser);
+						}
 					}
 				}
 			}

--- a/test/integration/data/validation/test-report-webdriverio.js
+++ b/test/integration/data/validation/test-report-webdriverio.js
@@ -13,126 +13,147 @@ export const testReportLatestPartial = {
 	},
 	details: [{
 		name: `[${platform}] > taxonomy overrides > passed`,
+		browser: 'chrome',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/webdriverio/taxonomy-overrides.test.js' },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
 		name: `[${platform}] > taxonomy overrides > skipped`,
+		browser: 'chrome',
 		status: 'skipped',
 		location: { file: 'test/integration/data/tests/webdriverio/taxonomy-overrides.test.js' },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
 		name: `[${platform}] > taxonomy overrides > flaky`,
+		browser: 'chrome',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/webdriverio/taxonomy-overrides.test.js' },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 2
 	}, {
 		name: `[${platform}] > taxonomy overrides > failed`,
+		browser: 'chrome',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/webdriverio/taxonomy-overrides.test.js' },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 3
 	}, {
 		name: `[${platform}] > statuses > passed`,
+		browser: 'chrome',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/webdriverio/statuses.test.js' },
 		taxonomy: { tool: 'WebdriverIO 1 Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: `[${platform}] > statuses > skipped`,
+		browser: 'chrome',
 		status: 'skipped',
 		location: { file: 'test/integration/data/tests/webdriverio/statuses.test.js' },
 		taxonomy: { tool: 'WebdriverIO 1 Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: `[${platform}] > statuses > flaky`,
+		browser: 'chrome',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/webdriverio/statuses.test.js' },
 		taxonomy: { tool: 'WebdriverIO 1 Test Reporting', type: 'ui' },
 		retries: 2
 	}, {
 		name: `[${platform}] > statuses > failed`,
+		browser: 'chrome',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/webdriverio/statuses.test.js' },
 		taxonomy: { tool: 'WebdriverIO 1 Test Reporting', type: 'ui' },
 		retries: 3
 	}, {
 		name: `[${platform}] > special characters > special/characters "(\\n\\r\\t\\b\\f)"`,
+		browser: 'chrome',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/webdriverio/special-characters.test.js' },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
 		name: `[${platform}] > hook failures > before all failure > test with before all failure`,
+		browser: 'chrome',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/webdriverio/hook-failures.test.js' },
 		taxonomy: { tool: 'WebdriverIO Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: `[${platform}] > hook failures > before each failure > test with before each failure`,
+		browser: 'chrome',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/webdriverio/hook-failures.test.js' },
 		taxonomy: { tool: 'WebdriverIO Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: `[${platform}] > hook failures > after each failure > test with after each failure`,
+		browser: 'chrome',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/webdriverio/hook-failures.test.js' },
 		taxonomy: { tool: 'WebdriverIO Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: `[${platform}] > hook failures > after all failure > test with after all failure`,
+		browser: 'chrome',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/webdriverio/hook-failures.test.js' },
 		taxonomy: { tool: 'WebdriverIO Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: `[${platform}] > hook failures > flaky before all > test with flaky before all`,
+		browser: 'chrome',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/webdriverio/hook-failures.test.js' },
 		taxonomy: { tool: 'WebdriverIO Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: `[${platform}] > hook failures > flaky before each > test with flaky before each`,
+		browser: 'chrome',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/webdriverio/hook-failures.test.js' },
 		taxonomy: { tool: 'WebdriverIO Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: `[${platform}] > hook failures > flaky after each > test with flaky after each`,
+		browser: 'chrome',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/webdriverio/hook-failures.test.js' },
 		taxonomy: { tool: 'WebdriverIO Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: `[${platform}] > hook failures > flaky after all > test with flaky after all`,
+		browser: 'chrome',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/webdriverio/hook-failures.test.js' },
 		taxonomy: { tool: 'WebdriverIO Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: `[${platform}] > fake timers > passed`,
+		browser: 'chrome',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/webdriverio/fake-timers.test.js' },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
 		name: `[${platform}] > fake timers > failed`,
+		browser: 'chrome',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/webdriverio/fake-timers.test.js' },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 3
 	}, {
 		name: `[${platform}] > custom timeout > suite level timeout`,
+		browser: 'chrome',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/webdriverio/custom-timeout.test.js' },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
 		name: `[${platform}] > custom timeout > test level timeout`,
+		browser: 'chrome',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/webdriverio/custom-timeout.test.js' },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },


### PR DESCRIPTION
Populates the `browser` field on WebdriverIO report details from `capabilities.browserName` (validated against `ReportBuilder.SupportedBrowsers`), mirroring the Playwright reporter. When `browserName` is unset (e.g. native app runs) no browser is recorded, and an unsupported `browserName` is omitted with a warning (the same warning is added to the Playwright resolver for parity). The WebdriverIO validation fixture now asserts `browser` on each detail.

https://desire2learn.atlassian.net/browse/QE-2205