### PR TITLE
fix: validate browser in Web Test Runner reporter

### DIFF
--- a/src/reporters/web-test-runner.js
+++ b/src/reporters/web-test-runner.js
@@ -32,6 +32,20 @@ const makeDetailId = (sessionId, file, name) => {
 	return `${sessionId}/${file}/${name}`;
 };
 
+const getBrowser = (browserName, logger) => {
+	const browser = browserName?.trim().toLowerCase();
+
+	if (ReportBuilder.SupportedBrowsers.includes(browser)) {
+		return browser;
+	}
+
+	if (browser) {
+		logger.warning(`Unsupported browser '${browser}', omitting from test report detail`);
+	}
+
+	return null;
+};
+
 export function reporter(options = {}) {
 	let overallStarted;
 	let testConfig;
@@ -65,7 +79,7 @@ export function reporter(options = {}) {
 			return;
 		}
 
-		const browser = browserName.toLowerCase();
+		const browser = getBrowser(browserName, logger);
 		const { testsFinishTimeout } = testConfig;
 
 		for (const test of tests) {
@@ -77,8 +91,11 @@ export function reporter(options = {}) {
 				.setName(testName)
 				.setLocationFile(testFile)
 				.setStarted(started)
-				.setBrowser(browser)
 				.setTimeout(testsFinishTimeout);
+
+			if (browser) {
+				detail.setBrowser(browser);
+			}
 
 			if (passed) {
 				detail.setPassed();


### PR DESCRIPTION
Makes the Web Test Runner reporter consistent with the Playwright and WebdriverIO reporters by validating the browser name against `ReportBuilder.SupportedBrowsers` and omitting it (with a warning) when unsupported, instead of writing the raw session browser name into the report.

https://desire2learn.atlassian.net/browse/QE-2214