### PR TITLE
Document reporter data limitations

### DIFF
--- a/docs/reporters/mocha.md
+++ b/docs/reporters/mocha.md
@@ -42,5 +42,9 @@ module.exports = {
 };
 ```
 
+> [!NOTE]
+> Mocha does not expose source line and column information, so each test detail
+> records only the file path under `location`.
+
 <!-- links -->
 [official documentation for Mocha]: https://mochajs.org/api/mocha#reporter

--- a/docs/reporters/playwright.md
+++ b/docs/reporters/playwright.md
@@ -72,6 +72,9 @@ export default defineConfig({
 });
 ```
 
+> [!NOTE]
+> Browsers not supported by the report schema are omitted from the detail.
+
 <!-- links -->
 [official documentation for Playwright]: https://playwright.dev/docs/test-reporters
 [`merge-reports`]: https://playwright.dev/docs/test-sharding#merge-reports-cli

--- a/docs/reporters/web-test-runner.md
+++ b/docs/reporters/web-test-runner.md
@@ -61,5 +61,12 @@ export default {
 };
 ```
 
+> [!NOTE]
+> `@web/test-runner` does not report per-test retries or source line and column
+> information, so each detail records `0` retries and only the file path under
+> `location`. The configured global `testsFinishTimeout` value is used for the
+> timeout rather than a per-test timeout. Browsers not supported by the report
+> schema are omitted from the detail.
+
 <!-- links -->
 [official documentation for `@web/test-runner`]: https://modern-web.dev/docs/test-runner/reporters/overview/

--- a/docs/reporters/webdriverio.md
+++ b/docs/reporters/webdriverio.md
@@ -70,5 +70,10 @@ export const config = {
 };
 ```
 
+> [!NOTE]
+> WebdriverIO does not expose source line and column information, so each test
+> detail records only the file path under `location`. Browsers not supported by
+> the report schema are omitted from the detail.
+
 <!-- links -->
 [official documentation for WebdriverIO]: https://webdriver.io/docs/customreporter


### PR DESCRIPTION
Adds notes to the reporter docs describing per-reporter data limitations: Mocha, Web Test Runner, and WebdriverIO omit source `location` line/column; Web Test Runner additionally records no per-test retries and uses the global `testsFinishTimeout`; and Playwright, WebdriverIO, and Web Test Runner omit browsers not supported by the report schema.

https://desire2learn.atlassian.net/browse/QE-2214