### PR TITLE
Document Mocha hook limitations

### DIFF
--- a/docs/reporters/mocha.md
+++ b/docs/reporters/mocha.md
@@ -44,7 +44,10 @@ module.exports = {
 
 > [!NOTE]
 > Mocha does not expose source line and column information, so each test detail
-> records only the file path under `location`.
+> records only the file path under `location`. Mocha also does not retry failing
+> hooks, so a `before` or `after` hook failure is recorded against the affected
+> test as a single failure with no retries, even when the test is configured
+> with retries.
 
 <!-- links -->
 [official documentation for Mocha]: https://mochajs.org/api/mocha#reporter

--- a/test/integration/data/tests/mocha/hook-failures.test.js
+++ b/test/integration/data/tests/mocha/hook-failures.test.js
@@ -2,37 +2,31 @@ const delay = (ms = 50) => {
 	return new Promise(resolve => setTimeout(resolve, ms));
 };
 
-// Mocha does not retry hook failures.
 describe('hook failures', () => {
-	// no test events fire — _onTestFail sets name, file, started, timeout, duration = 0, status = failed
 	describe('before all failure', () => {
 		before(() => { throw new Error('before all hook failure'); });
 
 		it('test with before all failure', async() => { await delay(); });
 	});
 
-	// _onTestBegin sets name, file, started, timeout — _onTestFail sets duration = 0, status = failed
 	describe('before each failure', () => {
 		beforeEach(() => { throw new Error('before each hook failure'); });
 
 		it('test with before each failure', async() => { await delay(); });
 	});
 
-	// _onTestBegin/End complete normally — _onTestFail is ignored (status already set)
 	describe('after each failure', () => {
 		afterEach(() => { throw new Error('after each hook failure'); });
 
 		it('test with after each failure', async() => { await delay(); });
 	});
 
-	// _onTestBegin/End complete normally — _onTestFail is ignored (status already set)
 	describe('after all failure', () => {
 		after(() => { throw new Error('after all hook failure'); });
 
 		it('test with after all failure', async() => { await delay(); });
 	});
 
-	// same as before all failure — _onTestFail sets name, file, started, timeout, duration = 0, status = failed
 	describe('flaky before all', () => {
 		let beforeAllCount = 0;
 
@@ -47,7 +41,6 @@ describe('hook failures', () => {
 		it('test with flaky before all', async() => { await delay(); });
 	});
 
-	// same as before each failure — _onTestFail sets duration = 0, status = failed
 	describe('flaky before each', () => {
 		let beforeEachCount = 0;
 
@@ -62,7 +55,6 @@ describe('hook failures', () => {
 		it('test with flaky before each', async() => { await delay(); });
 	});
 
-	// same as after each failure — _onTestFail ignored, status = passed
 	describe('flaky after each', () => {
 		let afterEachCount = 0;
 
@@ -77,7 +69,6 @@ describe('hook failures', () => {
 		it('test with flaky after each', async() => { await delay(); });
 	});
 
-	// same as after all failure — _onTestFail ignored, status = passed
 	describe('flaky after all', () => {
 		let afterAllCount = 0;
 


### PR DESCRIPTION
Documents that Mocha hook failures are recorded without retries even when tests are configured to retry. Also removes explanatory comments from the Mocha hook-failure integration fixture.

https://desire2learn.atlassian.net/browse/QE-2217