### PR TITLE
fix: refactor Node reporter into a Transform class with spec-style colored logs

### DIFF
--- a/docs/reporters/node.md
+++ b/docs/reporters/node.md
@@ -31,13 +31,13 @@ variables.
 
 ## Programmatic Usage
 
-For finer control, use the named `reporter` factory with the [`run()`] API and
-compose it onto the test stream.
+For finer control, use the default export with the [`run()`] API and compose an
+instance onto the test stream.
 
 ```js
 import { readdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { reporter } from 'd2l-test-reporting/reporters/node.js';
+import NodeReporter from 'd2l-test-reporting/reporters/node.js';
 import { run } from 'node:test';
 
 const testDirectory = 'test';
@@ -45,7 +45,7 @@ const files = readdirSync(testDirectory)
   .filter(name => name.endsWith('.test.js'))
   .map(name => join(testDirectory, name));
 
-const stream = run({ files }).compose(reporter());
+const stream = run({ files }).compose(new NodeReporter());
 
 stream.on('data', () => {});
 stream.on('error', () => {});
@@ -53,7 +53,7 @@ stream.on('error', () => {});
 
 ## Inputs
 
-The `reporter` factory accepts the following options. When running through the
+The reporter constructor accepts the following options. When running through the
 CLI, the corresponding environment variable is used instead.
 
 * `reportPath` / `D2L_TEST_REPORTING_REPORT_PATH` (default:
@@ -74,14 +74,14 @@ reference if any values need to be customized.
 ```js
 import { readdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { reporter } from 'd2l-test-reporting/reporters/node.js';
+import NodeReporter from 'd2l-test-reporting/reporters/node.js';
 import { run } from 'node:test';
 
 const testDirectory = 'test';
 const files = readdirSync(testDirectory)
   .filter(name => name.endsWith('.test.js'))
   .map(name => join(testDirectory, name));
-const stream = run({ files }).compose(reporter({
+const stream = run({ files }).compose(new NodeReporter({
   reportPath: './d2l-test-report.json',
   reportConfigurationPath: './d2l-test-reporting.config.json',
   verbose: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "lodash": "^4",
         "minimatch": "^10",
         "mocha": "^11",
-        "playwright-core": "^1"
+        "playwright-core": "^1",
+        "yn": "^5"
       },
       "devDependencies": {
         "@actions/artifact": "^6",
@@ -50,8 +51,7 @@
         "npm-run-all": "^4",
         "playwright": "^1",
         "sinon": "^22",
-        "webdriverio": "^9",
-        "yn": "^5"
+        "webdriverio": "^9"
       },
       "engines": {
         "node": ">=22"
@@ -19557,7 +19557,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/yn/-/yn-5.1.0.tgz",
       "integrity": "sha512-TfXLvT6eVsBNIm8rAXTwJYdQFtOXaHQ+rA7LU8HL8C/BFfaSfhvFE5T1rHAdBCbAj808HaqjXVkmo8jmeGOqhw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "lodash": "^4",
     "minimatch": "^10",
     "mocha": "^11",
-    "playwright-core": "^1"
+    "playwright-core": "^1",
+    "yn": "^5"
   },
   "devDependencies": {
     "@actions/artifact": "^6",
@@ -89,8 +90,7 @@
     "npm-run-all": "^4",
     "playwright": "^1",
     "sinon": "^22",
-    "webdriverio": "^9",
-    "yn": "^5"
+    "webdriverio": "^9"
   },
   "engines": {
     "node": ">=22"

--- a/src/reporters/node.js
+++ b/src/reporters/node.js
@@ -1,5 +1,8 @@
 import { createRequire } from 'node:module';
+import { env } from 'node:process';
 import { Transform } from 'node:stream';
+import { styleText } from 'node:util';
+import yn from 'yn';
 
 const require = createRequire(import.meta.url);
 
@@ -12,20 +15,20 @@ class NodeTestLogger {
 		const lines = `${message}`.split(/\r?\n/u);
 
 		for (const line of lines) {
-			console.log(`[D2L Reporter] ${line}`);
+			console.log(styleText('blue', `\u2139 ${line}`));
 		}
 	}
 
 	warning(message) {
-		console.warn(`[D2L Reporter] ${message}`);
+		console.warn(styleText('yellow', `\u26A0 ${message}`));
 	}
 
 	error(message) {
-		console.error(`[D2L Reporter] ${message}`);
+		console.error(styleText('red', `\u2716 ${message}`));
 	}
 
 	location(message, location) {
-		this.info(`${message}: ${location}`);
+		console.log(styleText('blue', `\u2139 ${message}: ${location}`));
 	}
 }
 
@@ -37,61 +40,51 @@ const makeDetailId = (file, name) => {
 	return `${file}[${name}]`;
 };
 
-const getOptionsFromEnvironment = () => {
-	const {
-		D2L_TEST_REPORTING_REPORT_PATH,
-		D2L_TEST_REPORTING_REPORT_CONFIGURATION_PATH,
-		D2L_TEST_REPORTING_VERBOSE
-	} = process.env;
-	const options = {};
-
-	if (D2L_TEST_REPORTING_REPORT_PATH) {
-		options.reportPath = D2L_TEST_REPORTING_REPORT_PATH;
-	}
-
-	if (D2L_TEST_REPORTING_REPORT_CONFIGURATION_PATH) {
-		options.reportConfigurationPath = D2L_TEST_REPORTING_REPORT_CONFIGURATION_PATH;
-	}
-
-	if (D2L_TEST_REPORTING_VERBOSE) {
-		options.verbose = ['1', 'true', 'yes'].includes(D2L_TEST_REPORTING_VERBOSE.trim().toLowerCase());
-	}
-
-	return options;
-};
-
-class NodeTestReporter extends Transform {
-	#anyFailure;
-	#logger;
-	#nameStacks;
-	#report;
-	#runStarted;
-	#startTimes;
-	#summary;
+class NodeReporter extends Transform {
+	#logger = new NodeTestLogger();
+	#nameStacks = new Map();
+	#startTimes = new Map();
+	#report = null;
+	#summary = null;
+	#runStarted = null;
+	#anyFailure = false;
 
 	constructor(options = {}) {
-		super({ objectMode: true });
+		super({ writableObjectMode: true });
 
-		this.#logger = new NodeTestLogger();
-		this.#nameStacks = new Map();
-		this.#startTimes = new Map();
-		this.#anyFailure = false;
-		this.#report = null;
+		const resolvedOptions = { ...options };
+		const {
+			D2L_TEST_REPORTING_REPORT_PATH,
+			D2L_TEST_REPORTING_REPORT_CONFIGURATION_PATH,
+			D2L_TEST_REPORTING_VERBOSE
+		} = env;
+
+		if (D2L_TEST_REPORTING_REPORT_PATH) {
+			resolvedOptions.reportPath ??= D2L_TEST_REPORTING_REPORT_PATH;
+		}
+
+		if (D2L_TEST_REPORTING_REPORT_CONFIGURATION_PATH) {
+			resolvedOptions.reportConfigurationPath ??= D2L_TEST_REPORTING_REPORT_CONFIGURATION_PATH;
+		}
+
+		if (D2L_TEST_REPORTING_VERBOSE) {
+			resolvedOptions.verbose ??= yn(D2L_TEST_REPORTING_VERBOSE, { default: false });
+		}
 
 		try {
-			this.#report = new ReportBuilder('node', this.#logger, options);
+			this.#report = new ReportBuilder('node', this.#logger, resolvedOptions);
 		} catch ({ message }) {
 			this.#logger.error('Failed to initialize D2L test report builder, report will not be generated');
 			this.#logger.error(message);
-
-			return;
 		}
 
-		this.#runStarted = getNow();
-		this.#summary = this.#report
-			.getSummary()
-			.addContext()
-			.setStarted(this.#runStarted.toISOString());
+		if (this.#report) {
+			this.#runStarted = getNow();
+			this.#summary = this.#report
+				.getSummary()
+				.addContext()
+				.setStarted(this.#runStarted.toISOString());
+		}
 	}
 
 	#getNameStack(file) {
@@ -184,10 +177,16 @@ class NodeTestReporter extends Transform {
 			return;
 		}
 
-		if (type === 'test:start') {
-			this.#handleStart(data);
-		} else if (type === 'test:pass' || type === 'test:fail') {
-			this.#handleResult(type, data);
+		switch (type) {
+			case 'test:start':
+				this.#handleStart(data);
+
+				break;
+			case 'test:pass':
+			case 'test:fail':
+				this.#handleResult(type, data);
+
+				break;
 		}
 
 		callback();
@@ -208,6 +207,8 @@ class NodeTestReporter extends Transform {
 
 		if (this.#anyFailure) {
 			this.#summary.setFailed();
+
+			process.exitCode = 1;
 		} else {
 			this.#summary.setPassed();
 		}
@@ -220,8 +221,4 @@ class NodeTestReporter extends Transform {
 	}
 }
 
-export const reporter = (options = {}) => {
-	return new NodeTestReporter(options);
-};
-
-export default new NodeTestReporter(getOptionsFromEnvironment());
+export default NodeReporter;

--- a/test/integration/data/configs/node.js
+++ b/test/integration/data/configs/node.js
@@ -1,6 +1,6 @@
 import { readdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { reporter } from '../../../../src/reporters/node.js';
+import NodeReporter from '../../../../src/reporters/node.js';
 import { run } from 'node:test';
 
 const testDirectory = 'test/integration/data/tests/node';
@@ -11,7 +11,7 @@ const files = readdirSync(testDirectory)
 const stream = run({
 	files,
 	concurrency: true
-}).compose(reporter({
+}).compose(new NodeReporter({
 	reportPath: './d2l-test-report-node.json',
 	reportConfigurationPath: './test/integration/data/d2l-test-reporting.config.json',
 	verbose: true


### PR DESCRIPTION
Restructures the Node test runner reporter into a `NodeReporter` class extending `Transform` (mirroring Node's `spec` reporter), replacing the factory and import-time instantiation. Logging now uses `util.styleText` with spec-style symbols (`ℹ` info, `⚠` warning, `✖` error), environment option resolution is inlined into the constructor, and `verbose` is parsed with `yn` (moved to `dependencies`). The integration config and `docs/reporters/node.md` now use the default class export.

https://desire2learn.atlassian.net/browse/QE-2218