### PR TITLE
fix: use util.styleText instead of chalk in web test runner reporter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "ajv": "^8",
         "ajv-errors": "^3",
         "ajv-formats": "^3",
-        "chalk": "^5",
         "codeowners": "^5",
         "lodash": "^4",
         "minimatch": "^10",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "ajv": "^8",
     "ajv-errors": "^3",
     "ajv-formats": "^3",
-    "chalk": "^5",
     "codeowners": "^5",
     "lodash": "^4",
     "minimatch": "^10",

--- a/src/reporters/web-test-runner.js
+++ b/src/reporters/web-test-runner.js
@@ -1,10 +1,8 @@
-import chalk from 'chalk';
 import { escapeSpecialCharacters } from '../helpers/strings.cjs';
 import { ReportBuilder } from '../helpers/report-builder.cjs';
 import { getNow, getNowISOString } from '../helpers/system.cjs';
 import { SESSION_STATUS } from '@web/test-runner-core';
-
-const { yellow, red, cyan, bold } = chalk;
+import { styleText } from 'node:util';
 
 class WebTestRunnerLogger {
 	info(message) {
@@ -15,9 +13,17 @@ class WebTestRunnerLogger {
 		}
 	}
 
-	warning(message) { this.info(yellow(bold(message))); }
-	error(message) { this.info(red(bold(message))); }
-	location(message, location) { this.info(`${message}: ${cyan(bold(location))}`); }
+	warning(message) {
+		this.info(styleText('yellow', styleText('bold', `${message}`)));
+	}
+
+	error(message) {
+		this.info(styleText('red', styleText('bold', `${message}`)));
+	}
+
+	location(message, location) {
+		this.info(`${message}: ${styleText('cyan', styleText('bold', `${location}`))}`);
+	}
 }
 
 const sanitizeName = (name) => {


### PR DESCRIPTION
Replaces `chalk` with Node's native `util.styleText` in the web test runner reporter logger, using nested `styleText` calls to mirror the previous `yellow(bold(...))` styling and stay compatible across the supported Node range. `chalk` is removed from `dependencies` since it is no longer used anywhere.

https://desire2learn.atlassian.net/browse/QE-2218