### PR TITLE
fix: remove lodash dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "ajv-formats": "^3",
         "chalk": "^5",
         "codeowners": "^5",
-        "lodash": "^4",
         "minimatch": "^10",
         "mocha": "^11",
         "playwright-core": "^1"
@@ -14073,6 +14072,7 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "ajv-formats": "^3",
     "chalk": "^5",
     "codeowners": "^5",
-    "lodash": "^4",
     "minimatch": "^10",
     "mocha": "^11",
     "playwright-core": "^1"

--- a/src/helpers/object.cjs
+++ b/src/helpers/object.cjs
@@ -26,4 +26,14 @@ const flatten = (obj) => {
 	return result;
 };
 
-module.exports = { flatten };
+const omit = (object, keys) => {
+	const result = { ...object };
+
+	for (const key of keys) {
+		delete result[key];
+	}
+
+	return result;
+};
+
+module.exports = { flatten, omit };

--- a/src/helpers/report.cjs
+++ b/src/helpers/report.cjs
@@ -1,8 +1,7 @@
 const schema = require('./schema.cjs');
-const { flatten } = require('./object.cjs');
+const { flatten, omit } = require('./object.cjs');
 const fs = require('node:fs');
 const { makeRelativeFilePath } = require('./system.cjs');
-const { omit } = require('lodash');
 const { resolve } = require('node:path');
 
 const {


### PR DESCRIPTION
Replaces the only `lodash` usage (`omit` in `report.cjs`) with a small local `omit` helper in `object.cjs` and removes `lodash` from `dependencies`.

https://desire2learn.atlassian.net/browse/QE-2218