### PR TITLE
fix: emit Node reporter report to the stream output

### DIFF
--- a/docs/reporters/node.md
+++ b/docs/reporters/node.md
@@ -10,32 +10,33 @@ how to use [custom reporters].
 ## CLI Usage
 
 The reporter has a default export that works directly with the
-`--test-reporter` flag. Pair it with another reporter (such as `spec`) to keep
-human readable output on the console.
+`--test-reporter` flag. It writes the report to its
+`--test-reporter-destination`, so point that at the report file. Pair it with
+another reporter (such as `spec`) to keep human readable output on the console.
 
 ```console
 node --test \
   --test-reporter=spec --test-reporter-destination=stdout \
-  --test-reporter=d2l-test-reporting/reporters/node.js --test-reporter-destination=stdout
+  --test-reporter=d2l-test-reporting/reporters/node.js --test-reporter-destination=./d2l-test-report.json
 ```
 
 > [!NOTE]
 > Node.js requires a `--test-reporter-destination` for every `--test-reporter`
-> when more than one reporter is used. The reporter writes the report file
-> itself (see `reportPath` under [Inputs]), so its destination receives no
-> output and `stdout` acts as a harmless placeholder.
+> when more than one reporter is used. The D2L reporter emits the report to its
+> destination, so set it to the file the report should be written to.
 
-Options are read from environment variables since the Node.js test runner does
-not forward options to custom reporters. See [Inputs] for the available
-variables.
+Remaining options are read from environment variables since the Node.js test
+runner does not forward options to custom reporters. See [Inputs] for the
+available variables.
 
 ## Programmatic Usage
 
 For finer control, use the default export with the [`run()`] API and compose an
-instance onto the test stream.
+instance onto the test stream. The reporter emits the report to its readable
+side, so pipe it to a destination such as a file write stream.
 
 ```js
-import { readdirSync } from 'node:fs';
+import { createWriteStream, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import NodeReporter from 'd2l-test-reporting/reporters/node.js';
 import { run } from 'node:test';
@@ -45,20 +46,20 @@ const files = readdirSync(testDirectory)
   .filter(name => name.endsWith('.test.js'))
   .map(name => join(testDirectory, name));
 
-const stream = run({ files }).compose(new NodeReporter());
-
-stream.on('data', () => {});
-stream.on('error', () => {});
+run({ files })
+  .compose(new NodeReporter())
+  .pipe(createWriteStream('./d2l-test-report.json'));
 ```
 
 ## Inputs
 
+The report is written to the stream destination: the
+`--test-reporter-destination` when running through the CLI, or whatever the
+reporter stream is piped to when running programmatically.
+
 The reporter constructor accepts the following options. When running through the
 CLI, the corresponding environment variable is used instead.
 
-* `reportPath` / `D2L_TEST_REPORTING_REPORT_PATH` (default:
-  `./d2l-test-report.json`): Path to output the report to, relative to current
-  working directory.
 * `reportConfigurationPath` / `D2L_TEST_REPORTING_REPORT_CONFIGURATION_PATH`
   (default: `./d2l-test-reporting.config.json`): Path to the D2L test reporting
   configuration file for mapping test type and tool to test code.
@@ -72,7 +73,7 @@ below shows every available option explicitly set, and is intended as a
 reference if any values need to be customized.
 
 ```js
-import { readdirSync } from 'node:fs';
+import { createWriteStream, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import NodeReporter from 'd2l-test-reporting/reporters/node.js';
 import { run } from 'node:test';
@@ -81,14 +82,13 @@ const testDirectory = 'test';
 const files = readdirSync(testDirectory)
   .filter(name => name.endsWith('.test.js'))
   .map(name => join(testDirectory, name));
-const stream = run({ files }).compose(new NodeReporter({
-  reportPath: './d2l-test-report.json',
-  reportConfigurationPath: './d2l-test-reporting.config.json',
-  verbose: true
-}));
 
-stream.on('data', () => {});
-stream.on('error', () => {});
+run({ files })
+  .compose(new NodeReporter({
+    reportConfigurationPath: './d2l-test-reporting.config.json',
+    verbose: true
+  }))
+  .pipe(createWriteStream('./d2l-test-report.json'));
 ```
 
 > [!NOTE]

--- a/src/reporters/node.js
+++ b/src/reporters/node.js
@@ -52,16 +52,17 @@ class NodeReporter extends Transform {
 	constructor(options = {}) {
 		super({ writableObjectMode: true });
 
-		const resolvedOptions = { ...options };
+		const resolvedOptions = {
+			reportConfigurationPath: options.reportConfigurationPath,
+			verbose: options.verbose,
+			reportWriter: (reportData) => {
+				this.push(reportData);
+			}
+		};
 		const {
-			D2L_TEST_REPORTING_REPORT_PATH,
 			D2L_TEST_REPORTING_REPORT_CONFIGURATION_PATH,
 			D2L_TEST_REPORTING_VERBOSE
 		} = env;
-
-		if (D2L_TEST_REPORTING_REPORT_PATH) {
-			resolvedOptions.reportPath ??= D2L_TEST_REPORTING_REPORT_PATH;
-		}
 
 		if (D2L_TEST_REPORTING_REPORT_CONFIGURATION_PATH) {
 			resolvedOptions.reportConfigurationPath ??= D2L_TEST_REPORTING_REPORT_CONFIGURATION_PATH;

--- a/test/integration/data/configs/node.js
+++ b/test/integration/data/configs/node.js
@@ -1,4 +1,4 @@
-import { readdirSync } from 'node:fs';
+import { createWriteStream, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import NodeReporter from '../../../../src/reporters/node.js';
 import { run } from 'node:test';
@@ -7,15 +7,11 @@ const testDirectory = 'test/integration/data/tests/node';
 const files = readdirSync(testDirectory)
 	.filter(name => name.endsWith('.test.js'))
 	.map(name => join(testDirectory, name));
-
-const stream = run({
-	files,
-	concurrency: true
-}).compose(new NodeReporter({
-	reportPath: './d2l-test-report-node.json',
+const reporterOptions = {
 	reportConfigurationPath: './test/integration/data/d2l-test-reporting.config.json',
 	verbose: true
-}));
+};
 
-stream.on('data', () => {});
-stream.on('error', () => {});
+run({ files, concurrency: true })
+	.compose(new NodeReporter(reporterOptions))
+	.pipe(createWriteStream('./d2l-test-report-node.json'));


### PR DESCRIPTION
Switches the Node reporter to push the serialized report to its readable stream (via the `reportWriter` hook) instead of writing the file itself, so the destination controls where the report lands: the `--test-reporter-destination` on the CLI or a piped write stream programmatically. Drops the `reportPath` / `D2L_TEST_REPORTING_REPORT_PATH` option and updates the docs and integration config accordingly.

Not doing as a breaking change as no one is using the node reporter yet.

https://desire2learn.atlassian.net/browse/QE-2218