### PR TITLE
Run repo unit and validation tests with the node reporter

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,10 +1,10 @@
 {
   "all": true,
   "check-coverage": true,
-  "statements": 80,
+  "statements": 85,
   "branches": 75,
   "functions": 85,
-  "lines": 80,
+  "lines": 85,
   "include": [
     "src/**/*.{js,cjs}"
   ],

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,3 +1,0 @@
-{
-  "reporter": "src/reporters/mocha.cjs"
-}

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "test:integration:playwright": "playwright test --config test/integration/data/configs/playwright.js || exit 0",
     "test:integration:web-test-runner": "wtr --config test/integration/data/configs/web-test-runner.js || exit 0",
     "test:integration:webdriverio": "wdio run test/integration/data/configs/webdriverio.cjs || exit 0",
-    "test:integration:validate-reports": "mocha --reporter-options reportPath=./d2l-test-report-validation.json --spec test/integration/report-validation.test.js",
-    "test:unit": "mocha --spec \"test/unit/**/*.test.js\""
+    "test:integration:validate-reports": "node --test --test-reporter=spec --test-reporter-destination=stdout --test-reporter=./src/reporters/node.js --test-reporter-destination=./d2l-test-report-validation.json test/integration/report-validation.test.js",
+    "test:unit": "node --test --test-reporter=spec --test-reporter-destination=stdout --test-reporter=./src/reporters/node.js --test-reporter-destination=./d2l-test-report.json \"test/unit/*.test.js\""
   },
   "dependencies": {
     "@wdio/reporter": "^9",

--- a/test/integration/data/configs/node.js
+++ b/test/integration/data/configs/node.js
@@ -2,6 +2,7 @@ import { createWriteStream, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import NodeReporter from '../../../../src/reporters/node.js';
 import { run } from 'node:test';
+import { spec } from 'node:test/reporters';
 
 const testDirectory = 'test/integration/data/tests/node';
 const files = readdirSync(testDirectory)
@@ -11,7 +12,12 @@ const reporterOptions = {
 	reportConfigurationPath: './test/integration/data/d2l-test-reporting.config.json',
 	verbose: true
 };
+const testStream = run({ files, concurrency: true });
 
-run({ files, concurrency: true })
+testStream
 	.compose(new NodeReporter(reporterOptions))
 	.pipe(createWriteStream('./d2l-test-report-node.json'));
+
+testStream
+	.compose(new spec())
+	.pipe(process.stdout);

--- a/test/integration/report-validation.test.js
+++ b/test/integration/report-validation.test.js
@@ -1,3 +1,4 @@
+import { describe, it } from 'node:test';
 import { existsSync } from 'node:fs';
 import { expect, use } from 'chai';
 import chaiSubset from 'chai-subset';

--- a/test/unit/github.test.js
+++ b/test/unit/github.test.js
@@ -1,3 +1,4 @@
+import { afterEach, before, describe, it } from 'node:test';
 import { getContext, hasContext } from '../../src/helpers/github.cjs';
 import { createSandbox } from 'sinon';
 import { expect } from 'chai';

--- a/test/unit/object.test.js
+++ b/test/unit/object.test.js
@@ -1,3 +1,4 @@
+import { describe, it } from 'node:test';
 import { expect } from 'chai';
 import { flatten } from '../../src/helpers/object.cjs';
 

--- a/test/unit/report-builder.test.js
+++ b/test/unit/report-builder.test.js
@@ -1,3 +1,4 @@
+import { afterEach, before, beforeEach, describe, it } from 'node:test';
 import chaiUuid from 'chai-uuid';
 import { createSandbox, match } from 'sinon';
 import { expect, use } from 'chai';

--- a/test/unit/report-configuration.test.js
+++ b/test/unit/report-configuration.test.js
@@ -1,3 +1,4 @@
+import { afterEach, before, beforeEach, describe, it } from 'node:test';
 import { createSandbox } from 'sinon';
 import { expect } from 'chai';
 import fs from 'node:fs';

--- a/test/unit/report.test.js
+++ b/test/unit/report.test.js
@@ -1,3 +1,4 @@
+import { afterEach, before, describe, it } from 'node:test';
 import { createSandbox } from 'sinon';
 import { expect } from 'chai';
 import { flatten } from '../../src/helpers/object.cjs';

--- a/test/unit/strings.test.js
+++ b/test/unit/strings.test.js
@@ -1,3 +1,4 @@
+import { describe, it } from 'node:test';
 import { expect } from 'chai';
 import { escapeSpecialCharacters } from '../../src/helpers/strings.cjs';
 

--- a/test/unit/system.test.js
+++ b/test/unit/system.test.js
@@ -1,3 +1,4 @@
+import { afterEach, before, beforeEach, describe, it } from 'node:test';
 import { getNow, getNowISOString, getOperatingSystemType, makeRelativeFilePath } from '../../src/helpers/system.cjs';
 import { createSandbox } from 'sinon';
 import { expect } from 'chai';


### PR DESCRIPTION
Switches this repo's own `test:unit` and `test:integration:validate-reports` scripts to run through `node --test` with the node reporter, writing each report to its `--test-reporter-destination`. Removes `.mocharc.json` and adds the `node:test` `describe`/`it` imports the runner needs.

https://desire2learn.atlassian.net/browse/QE-2218