### PR TITLE
Standardize integration test fixtures across frameworks

### DIFF
--- a/test/integration/data/configs/playwright.js
+++ b/test/integration/data/configs/playwright.js
@@ -19,7 +19,6 @@ export default defineConfig({
 	fullyParallel: true,
 	testDir: '../tests/playwright/',
 	testMatch: '*.test.js',
-	use: deviceTypeChrome,
 	globalSetup: '../tests/playwright/global.setup.js',
 	globalTeardown: '../tests/playwright/global.teardown.js',
 	projects: [{
@@ -31,6 +30,7 @@ export default defineConfig({
 		testMatch: 'teardown.js'
 	}, {
 		name: 'chromium',
+		use: deviceTypeChrome,
 		dependencies: ['setup']
 	}, {
 		name: 'firefox',

--- a/test/integration/data/configs/web-test-runner.js
+++ b/test/integration/data/configs/web-test-runner.js
@@ -11,13 +11,14 @@ export default {
 			verbose: true
 		})
 	],
-	files: './test/integration/data/tests/web-test-runner/*.test.js',
 	nodeResolve: true,
+	files: './test/integration/data/tests/web-test-runner/*.test.js',
+	browsers: [
+		playwrightLauncher({ product: 'chromium', launchOptions: { args: ['--no-sandbox'] } })
+	],
 	groups: [{
 		name: 'group 1',
-		files: './test/integration/data/tests/web-test-runner/*.test.js',
 		browsers: [
-			playwrightLauncher({ product: 'chromium', launchOptions: { args: ['--no-sandbox'] } }),
 			playwrightLauncher({ product: 'firefox' })
 		]
 	}, {

--- a/test/integration/data/tests/node/statuses.test.js
+++ b/test/integration/data/tests/node/statuses.test.js
@@ -1,17 +1,39 @@
-import { describe, it } from 'node:test';
+import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
 
 const delay = (ms = 50) => {
 	return new Promise(resolve => setTimeout(resolve, ms));
 };
 
 describe('statuses', () => {
+	let count = 0;
+
+	before(async() => { await delay(250); });
+
+	beforeEach(async() => { await delay(250); });
+
 	it('passed', async() => { await delay(); });
 
 	it('skipped', { skip: true }, () => {});
+
+	it('flaky', async() => {
+		if (count < 2) {
+			await delay();
+
+			count++;
+
+			throw new Error('flaky test failure');
+		}
+
+		await delay();
+	});
 
 	it('failed', async() => {
 		await delay();
 
 		throw new Error('fail');
 	});
+
+	afterEach(async() => { await delay(250); });
+
+	after(async() => { await delay(250); });
 });

--- a/test/integration/data/tests/node/taxonomy-overrides.test.js
+++ b/test/integration/data/tests/node/taxonomy-overrides.test.js
@@ -1,17 +1,39 @@
-import { describe, it } from 'node:test';
+import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
 
 const delay = (ms = 50) => {
 	return new Promise(resolve => setTimeout(resolve, ms));
 };
 
 describe('taxonomy overrides', () => {
+	let count = 0;
+
+	before(async() => { await delay(250); });
+
+	beforeEach(async() => { await delay(250); });
+
 	it('passed', async() => { await delay(); });
 
 	it('skipped', { skip: true }, () => {});
+
+	it('flaky', async() => {
+		if (count < 2) {
+			await delay();
+
+			count++;
+
+			throw new Error('flaky test failure');
+		}
+
+		await delay();
+	});
 
 	it('failed', async() => {
 		await delay();
 
 		throw new Error('fail');
 	});
+
+	afterEach(async() => { await delay(250); });
+
+	after(async() => { await delay(250); });
 });

--- a/test/integration/data/tests/web-test-runner/hook-failures.test.js
+++ b/test/integration/data/tests/web-test-runner/hook-failures.test.js
@@ -26,4 +26,60 @@ describe('hook failures', () => {
 
 		it('test with after all failure', async() => { await delay(); });
 	});
+
+	describe('flaky before all', () => {
+		let beforeAllCount = 0;
+
+		before(() => {
+			if (beforeAllCount < 2) {
+				beforeAllCount++;
+
+				throw new Error('flaky before all');
+			}
+		});
+
+		it('test with flaky before all', async() => { await delay(); });
+	});
+
+	describe('flaky before each', () => {
+		let beforeEachCount = 0;
+
+		beforeEach(() => {
+			if (beforeEachCount < 2) {
+				beforeEachCount++;
+
+				throw new Error('flaky before each');
+			}
+		});
+
+		it('test with flaky before each', async() => { await delay(); });
+	});
+
+	describe('flaky after each', () => {
+		let afterEachCount = 0;
+
+		afterEach(() => {
+			if (afterEachCount < 2) {
+				afterEachCount++;
+
+				throw new Error('flaky after each');
+			}
+		});
+
+		it('test with flaky after each', async() => { await delay(); });
+	});
+
+	describe('flaky after all', () => {
+		let afterAllCount = 0;
+
+		after(() => {
+			if (afterAllCount < 2) {
+				afterAllCount++;
+
+				throw new Error('flaky after all');
+			}
+		});
+
+		it('test with flaky after all', async() => { await delay(); });
+	});
 });

--- a/test/integration/data/tests/web-test-runner/statuses.test.js
+++ b/test/integration/data/tests/web-test-runner/statuses.test.js
@@ -3,6 +3,8 @@ const delay = (ms = 50) => {
 };
 
 describe('statuses', () => {
+	let count = 0;
+
 	before(async() => { await delay(250); });
 
 	beforeEach(async() => { await delay(250); });
@@ -10,6 +12,18 @@ describe('statuses', () => {
 	it('passed', async() => { await delay(); });
 
 	it.skip('skipped', () => {});
+
+	it('flaky', async() => {
+		if (count < 2) {
+			await delay();
+
+			count++;
+
+			throw new Error('flaky test failure');
+		}
+
+		await delay();
+	});
 
 	it('failed', () => { throw new Error('fail'); });
 

--- a/test/integration/data/tests/web-test-runner/taxonomy-overrides.test.js
+++ b/test/integration/data/tests/web-test-runner/taxonomy-overrides.test.js
@@ -3,6 +3,8 @@ const delay = (ms = 50) => {
 };
 
 describe('taxonomy overrides', () => {
+	let count = 0;
+
 	before(async() => { await delay(250); });
 
 	beforeEach(async() => { await delay(250); });
@@ -10,6 +12,18 @@ describe('taxonomy overrides', () => {
 	it('passed', async() => { await delay(); });
 
 	it.skip('skipped', () => {});
+
+	it('flaky', async() => {
+		if (count < 2) {
+			await delay();
+
+			count++;
+
+			throw new Error('flaky test failure');
+		}
+
+		await delay();
+	});
 
 	it('failed', () => { throw new Error('fail'); });
 

--- a/test/integration/data/validation/test-report-node.js
+++ b/test/integration/data/validation/test-report-node.js
@@ -5,7 +5,7 @@ export const testReportLatestPartial = {
 	summary: {
 		status: 'failed',
 		framework: 'node',
-		count: { passed: 8, failed: 9, skipped: 2, flaky: 0 }
+		count: { passed: 8, failed: 11, skipped: 2, flaky: 0 }
 	},
 	details: [{
 		name: 'custom timeout > suite level timeout',
@@ -98,6 +98,12 @@ export const testReportLatestPartial = {
 		taxonomy: { tool: 'Node 1 Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
+		name: 'statuses > flaky',
+		status: 'failed',
+		location: { file: 'test/integration/data/tests/node/statuses.test.js' },
+		taxonomy: { tool: 'Node 1 Test Reporting', type: 'ui' },
+		retries: 0
+	}, {
 		name: 'statuses > failed',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/node/statuses.test.js' },
@@ -112,6 +118,12 @@ export const testReportLatestPartial = {
 	}, {
 		name: 'taxonomy overrides > skipped',
 		status: 'skipped',
+		location: { file: 'test/integration/data/tests/node/taxonomy-overrides.test.js' },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 0
+	}, {
+		name: 'taxonomy overrides > flaky',
+		status: 'failed',
 		location: { file: 'test/integration/data/tests/node/taxonomy-overrides.test.js' },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0

--- a/test/integration/data/validation/test-report-web-test-runner.js
+++ b/test/integration/data/validation/test-report-web-test-runner.js
@@ -5,13 +5,13 @@ export const testReportLatestPartial = {
 	summary: {
 		status: 'failed',
 		framework: '@web/test-runner',
-		count: { passed: 32, failed: 20, skipped: 8, flaky: 0 }
+		count: { passed: 30, failed: 27, skipped: 6, flaky: 0 }
 	},
 	details: [{
 		name: 'custom timeout > suite level timeout',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/web-test-runner/custom-timeout.test.js' },
-		browser: 'chrome',
+		browser: 'chromium',
 		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
@@ -19,7 +19,7 @@ export const testReportLatestPartial = {
 		name: 'custom timeout > test level timeout',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/web-test-runner/custom-timeout.test.js' },
-		browser: 'chrome',
+		browser: 'chromium',
 		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
@@ -27,7 +27,7 @@ export const testReportLatestPartial = {
 		name: 'fake timers > passed',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/web-test-runner/fake-timers.test.js' },
-		browser: 'chrome',
+		browser: 'chromium',
 		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
@@ -35,7 +35,7 @@ export const testReportLatestPartial = {
 		name: 'fake timers > failed',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/web-test-runner/fake-timers.test.js' },
-		browser: 'chrome',
+		browser: 'chromium',
 		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
@@ -43,7 +43,7 @@ export const testReportLatestPartial = {
 		name: 'hook failures > before all failure > test with before all failure',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/web-test-runner/hook-failures.test.js' },
-		browser: 'chrome',
+		browser: 'chromium',
 		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
@@ -51,7 +51,7 @@ export const testReportLatestPartial = {
 		name: 'hook failures > before each failure > test with before each failure',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/web-test-runner/hook-failures.test.js' },
-		browser: 'chrome',
+		browser: 'chromium',
 		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
@@ -59,7 +59,7 @@ export const testReportLatestPartial = {
 		name: 'hook failures > after each failure > test with after each failure',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/web-test-runner/hook-failures.test.js' },
-		browser: 'chrome',
+		browser: 'chromium',
 		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
@@ -67,7 +67,39 @@ export const testReportLatestPartial = {
 		name: 'hook failures > after all failure > test with after all failure',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/web-test-runner/hook-failures.test.js' },
-		browser: 'chrome',
+		browser: 'chromium',
+		configuration: { timeout: 120000 },
+		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
+		retries: 0
+	}, {
+		name: 'hook failures > flaky before all > test with flaky before all',
+		status: 'failed',
+		location: { file: 'test/integration/data/tests/web-test-runner/hook-failures.test.js' },
+		browser: 'chromium',
+		configuration: { timeout: 120000 },
+		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
+		retries: 0
+	}, {
+		name: 'hook failures > flaky before each > test with flaky before each',
+		status: 'failed',
+		location: { file: 'test/integration/data/tests/web-test-runner/hook-failures.test.js' },
+		browser: 'chromium',
+		configuration: { timeout: 120000 },
+		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
+		retries: 0
+	}, {
+		name: 'hook failures > flaky after each > test with flaky after each',
+		status: 'passed',
+		location: { file: 'test/integration/data/tests/web-test-runner/hook-failures.test.js' },
+		browser: 'chromium',
+		configuration: { timeout: 120000 },
+		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
+		retries: 0
+	}, {
+		name: 'hook failures > flaky after all > test with flaky after all',
+		status: 'passed',
+		location: { file: 'test/integration/data/tests/web-test-runner/hook-failures.test.js' },
+		browser: 'chromium',
 		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
@@ -75,7 +107,7 @@ export const testReportLatestPartial = {
 		name: 'special characters > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/web-test-runner/special-characters.test.js' },
-		browser: 'chrome',
+		browser: 'chromium',
 		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
@@ -83,7 +115,7 @@ export const testReportLatestPartial = {
 		name: 'statuses > passed',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/web-test-runner/statuses.test.js' },
-		browser: 'chrome',
+		browser: 'chromium',
 		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'WebTestRunner 1 Test Reporting', type: 'ui' },
 		retries: 0
@@ -91,7 +123,15 @@ export const testReportLatestPartial = {
 		name: 'statuses > skipped',
 		status: 'skipped',
 		location: { file: 'test/integration/data/tests/web-test-runner/statuses.test.js' },
-		browser: 'chrome',
+		browser: 'chromium',
+		configuration: { timeout: 120000 },
+		taxonomy: { tool: 'WebTestRunner 1 Test Reporting', type: 'ui' },
+		retries: 0
+	}, {
+		name: 'statuses > flaky',
+		status: 'failed',
+		location: { file: 'test/integration/data/tests/web-test-runner/statuses.test.js' },
+		browser: 'chromium',
 		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'WebTestRunner 1 Test Reporting', type: 'ui' },
 		retries: 0
@@ -99,7 +139,7 @@ export const testReportLatestPartial = {
 		name: 'statuses > failed',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/web-test-runner/statuses.test.js' },
-		browser: 'chrome',
+		browser: 'chromium',
 		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'WebTestRunner 1 Test Reporting', type: 'ui' },
 		retries: 0
@@ -107,7 +147,7 @@ export const testReportLatestPartial = {
 		name: 'taxonomy overrides > passed',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/web-test-runner/taxonomy-overrides.test.js' },
-		browser: 'chrome',
+		browser: 'chromium',
 		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
@@ -115,7 +155,15 @@ export const testReportLatestPartial = {
 		name: 'taxonomy overrides > skipped',
 		status: 'skipped',
 		location: { file: 'test/integration/data/tests/web-test-runner/taxonomy-overrides.test.js' },
-		browser: 'chrome',
+		browser: 'chromium',
+		configuration: { timeout: 120000 },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 0
+	}, {
+		name: 'taxonomy overrides > flaky',
+		status: 'failed',
+		location: { file: 'test/integration/data/tests/web-test-runner/taxonomy-overrides.test.js' },
+		browser: 'chromium',
 		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
@@ -123,22 +171,6 @@ export const testReportLatestPartial = {
 		name: 'taxonomy overrides > failed',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/web-test-runner/taxonomy-overrides.test.js' },
-		browser: 'chrome',
-		configuration: { timeout: 120000 },
-		taxonomy: { tool: 'Test Reporting', type: 'integration' },
-		retries: 0
-	}, {
-		name: '[group 1] > custom timeout > suite level timeout',
-		status: 'passed',
-		location: { file: 'test/integration/data/tests/web-test-runner/custom-timeout.test.js' },
-		browser: 'chromium',
-		configuration: { timeout: 120000 },
-		taxonomy: { tool: 'Test Reporting', type: 'integration' },
-		retries: 0
-	}, {
-		name: '[group 1] > custom timeout > test level timeout',
-		status: 'passed',
-		location: { file: 'test/integration/data/tests/web-test-runner/custom-timeout.test.js' },
 		browser: 'chromium',
 		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
@@ -163,22 +195,6 @@ export const testReportLatestPartial = {
 		name: '[group 1] > fake timers > passed',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/web-test-runner/fake-timers.test.js' },
-		browser: 'chromium',
-		configuration: { timeout: 120000 },
-		taxonomy: { tool: 'Test Reporting', type: 'integration' },
-		retries: 0
-	}, {
-		name: '[group 1] > fake timers > failed',
-		status: 'failed',
-		location: { file: 'test/integration/data/tests/web-test-runner/fake-timers.test.js' },
-		browser: 'chromium',
-		configuration: { timeout: 120000 },
-		taxonomy: { tool: 'Test Reporting', type: 'integration' },
-		retries: 0
-	}, {
-		name: '[group 1] > fake timers > passed',
-		status: 'passed',
-		location: { file: 'test/integration/data/tests/web-test-runner/fake-timers.test.js' },
 		browser: 'firefox',
 		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
@@ -190,38 +206,6 @@ export const testReportLatestPartial = {
 		browser: 'firefox',
 		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
-		retries: 0
-	}, {
-		name: '[group 1] > hook failures > before all failure > test with before all failure',
-		status: 'failed',
-		location: { file: 'test/integration/data/tests/web-test-runner/hook-failures.test.js' },
-		browser: 'chromium',
-		configuration: { timeout: 120000 },
-		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
-		retries: 0
-	}, {
-		name: '[group 1] > hook failures > before each failure > test with before each failure',
-		status: 'failed',
-		location: { file: 'test/integration/data/tests/web-test-runner/hook-failures.test.js' },
-		browser: 'chromium',
-		configuration: { timeout: 120000 },
-		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
-		retries: 0
-	}, {
-		name: '[group 1] > hook failures > after each failure > test with after each failure',
-		status: 'passed',
-		location: { file: 'test/integration/data/tests/web-test-runner/hook-failures.test.js' },
-		browser: 'chromium',
-		configuration: { timeout: 120000 },
-		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
-		retries: 0
-	}, {
-		name: '[group 1] > hook failures > after all failure > test with after all failure',
-		status: 'passed',
-		location: { file: 'test/integration/data/tests/web-test-runner/hook-failures.test.js' },
-		browser: 'chromium',
-		configuration: { timeout: 120000 },
-		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
 		name: '[group 1] > hook failures > before all failure > test with before all failure',
@@ -256,44 +240,44 @@ export const testReportLatestPartial = {
 		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
-		name: '[group 1] > special characters > special/characters "(\\n\\r\\t\\b\\f)"',
-		status: 'passed',
-		location: { file: 'test/integration/data/tests/web-test-runner/special-characters.test.js' },
-		browser: 'chromium',
-		configuration: { timeout: 120000 },
-		taxonomy: { tool: 'Test Reporting', type: 'integration' },
-		retries: 0
-	}, {
-		name: '[group 1] > special characters > special/characters "(\\n\\r\\t\\b\\f)"',
-		status: 'passed',
-		location: { file: 'test/integration/data/tests/web-test-runner/special-characters.test.js' },
-		browser: 'firefox',
-		configuration: { timeout: 120000 },
-		taxonomy: { tool: 'Test Reporting', type: 'integration' },
-		retries: 0
-	}, {
-		name: '[group 1] > statuses > passed',
-		status: 'passed',
-		location: { file: 'test/integration/data/tests/web-test-runner/statuses.test.js' },
-		browser: 'chromium',
-		configuration: { timeout: 120000 },
-		taxonomy: { tool: 'WebTestRunner 1 Test Reporting', type: 'ui' },
-		retries: 0
-	}, {
-		name: '[group 1] > statuses > skipped',
-		status: 'skipped',
-		location: { file: 'test/integration/data/tests/web-test-runner/statuses.test.js' },
-		browser: 'chromium',
-		configuration: { timeout: 120000 },
-		taxonomy: { tool: 'WebTestRunner 1 Test Reporting', type: 'ui' },
-		retries: 0
-	}, {
-		name: '[group 1] > statuses > failed',
+		name: '[group 1] > hook failures > flaky before all > test with flaky before all',
 		status: 'failed',
-		location: { file: 'test/integration/data/tests/web-test-runner/statuses.test.js' },
-		browser: 'chromium',
+		location: { file: 'test/integration/data/tests/web-test-runner/hook-failures.test.js' },
+		browser: 'firefox',
 		configuration: { timeout: 120000 },
-		taxonomy: { tool: 'WebTestRunner 1 Test Reporting', type: 'ui' },
+		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
+		retries: 0
+	}, {
+		name: '[group 1] > hook failures > flaky before each > test with flaky before each',
+		status: 'failed',
+		location: { file: 'test/integration/data/tests/web-test-runner/hook-failures.test.js' },
+		browser: 'firefox',
+		configuration: { timeout: 120000 },
+		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
+		retries: 0
+	}, {
+		name: '[group 1] > hook failures > flaky after each > test with flaky after each',
+		status: 'passed',
+		location: { file: 'test/integration/data/tests/web-test-runner/hook-failures.test.js' },
+		browser: 'firefox',
+		configuration: { timeout: 120000 },
+		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
+		retries: 0
+	}, {
+		name: '[group 1] > hook failures > flaky after all > test with flaky after all',
+		status: 'passed',
+		location: { file: 'test/integration/data/tests/web-test-runner/hook-failures.test.js' },
+		browser: 'firefox',
+		configuration: { timeout: 120000 },
+		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
+		retries: 0
+	}, {
+		name: '[group 1] > special characters > special/characters "(\\n\\r\\t\\b\\f)"',
+		status: 'passed',
+		location: { file: 'test/integration/data/tests/web-test-runner/special-characters.test.js' },
+		browser: 'firefox',
+		configuration: { timeout: 120000 },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
 		name: '[group 1] > statuses > passed',
@@ -306,6 +290,14 @@ export const testReportLatestPartial = {
 	}, {
 		name: '[group 1] > statuses > skipped',
 		status: 'skipped',
+		location: { file: 'test/integration/data/tests/web-test-runner/statuses.test.js' },
+		browser: 'firefox',
+		configuration: { timeout: 120000 },
+		taxonomy: { tool: 'WebTestRunner 1 Test Reporting', type: 'ui' },
+		retries: 0
+	}, {
+		name: '[group 1] > statuses > flaky',
+		status: 'failed',
 		location: { file: 'test/integration/data/tests/web-test-runner/statuses.test.js' },
 		browser: 'firefox',
 		configuration: { timeout: 120000 },
@@ -323,30 +315,6 @@ export const testReportLatestPartial = {
 		name: '[group 1] > taxonomy overrides > passed',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/web-test-runner/taxonomy-overrides.test.js' },
-		browser: 'chromium',
-		configuration: { timeout: 120000 },
-		taxonomy: { tool: 'Test Reporting', type: 'integration' },
-		retries: 0
-	}, {
-		name: '[group 1] > taxonomy overrides > skipped',
-		status: 'skipped',
-		location: { file: 'test/integration/data/tests/web-test-runner/taxonomy-overrides.test.js' },
-		browser: 'chromium',
-		configuration: { timeout: 120000 },
-		taxonomy: { tool: 'Test Reporting', type: 'integration' },
-		retries: 0
-	}, {
-		name: '[group 1] > taxonomy overrides > failed',
-		status: 'failed',
-		location: { file: 'test/integration/data/tests/web-test-runner/taxonomy-overrides.test.js' },
-		browser: 'chromium',
-		configuration: { timeout: 120000 },
-		taxonomy: { tool: 'Test Reporting', type: 'integration' },
-		retries: 0
-	}, {
-		name: '[group 1] > taxonomy overrides > passed',
-		status: 'passed',
-		location: { file: 'test/integration/data/tests/web-test-runner/taxonomy-overrides.test.js' },
 		browser: 'firefox',
 		configuration: { timeout: 120000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
@@ -354,6 +322,14 @@ export const testReportLatestPartial = {
 	}, {
 		name: '[group 1] > taxonomy overrides > skipped',
 		status: 'skipped',
+		location: { file: 'test/integration/data/tests/web-test-runner/taxonomy-overrides.test.js' },
+		browser: 'firefox',
+		configuration: { timeout: 120000 },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 0
+	}, {
+		name: '[group 1] > taxonomy overrides > flaky',
+		status: 'failed',
 		location: { file: 'test/integration/data/tests/web-test-runner/taxonomy-overrides.test.js' },
 		browser: 'firefox',
 		configuration: { timeout: 120000 },
@@ -432,6 +408,38 @@ export const testReportLatestPartial = {
 		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
+		name: '[group 2] > hook failures > flaky before all > test with flaky before all',
+		status: 'failed',
+		location: { file: 'test/integration/data/tests/web-test-runner/hook-failures.test.js' },
+		browser: 'webkit',
+		configuration: { timeout: 120000 },
+		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
+		retries: 0
+	}, {
+		name: '[group 2] > hook failures > flaky before each > test with flaky before each',
+		status: 'failed',
+		location: { file: 'test/integration/data/tests/web-test-runner/hook-failures.test.js' },
+		browser: 'webkit',
+		configuration: { timeout: 120000 },
+		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
+		retries: 0
+	}, {
+		name: '[group 2] > hook failures > flaky after each > test with flaky after each',
+		status: 'passed',
+		location: { file: 'test/integration/data/tests/web-test-runner/hook-failures.test.js' },
+		browser: 'webkit',
+		configuration: { timeout: 120000 },
+		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
+		retries: 0
+	}, {
+		name: '[group 2] > hook failures > flaky after all > test with flaky after all',
+		status: 'passed',
+		location: { file: 'test/integration/data/tests/web-test-runner/hook-failures.test.js' },
+		browser: 'webkit',
+		configuration: { timeout: 120000 },
+		taxonomy: { tool: 'WebTestRunner Hook Failures Test Reporting', type: 'ui' },
+		retries: 0
+	}, {
 		name: '[group 2] > special characters > special/characters "(\\n\\r\\t\\b\\f)"',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/web-test-runner/special-characters.test.js' },
@@ -456,6 +464,14 @@ export const testReportLatestPartial = {
 		taxonomy: { tool: 'WebTestRunner 1 Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
+		name: '[group 2] > statuses > flaky',
+		status: 'failed',
+		location: { file: 'test/integration/data/tests/web-test-runner/statuses.test.js' },
+		browser: 'webkit',
+		configuration: { timeout: 120000 },
+		taxonomy: { tool: 'WebTestRunner 1 Test Reporting', type: 'ui' },
+		retries: 0
+	}, {
 		name: '[group 2] > statuses > failed',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/web-test-runner/statuses.test.js' },
@@ -474,6 +490,14 @@ export const testReportLatestPartial = {
 	}, {
 		name: '[group 2] > taxonomy overrides > skipped',
 		status: 'skipped',
+		location: { file: 'test/integration/data/tests/web-test-runner/taxonomy-overrides.test.js' },
+		browser: 'webkit',
+		configuration: { timeout: 120000 },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 0
+	}, {
+		name: '[group 2] > taxonomy overrides > flaky',
+		status: 'failed',
 		location: { file: 'test/integration/data/tests/web-test-runner/taxonomy-overrides.test.js' },
 		browser: 'webkit',
 		configuration: { timeout: 120000 },


### PR DESCRIPTION
Aligns the integration test fixtures across all six frameworks (`node`, `jest`, `mocha`, `playwright`, `web-test-runner`, `webdriverio`) so their generated reports share a consistent makeup, and updates the affected validation fixtures to match.

The `node` `statuses` and `taxonomy-overrides` fixtures gain the canonical hooks and flaky variants, `web-test-runner` fixtures pick up the flaky and flaky-hook variants, and `playwright` and `web-test-runner` are aligned to the same three browsers (`chromium`, `firefox`, `webkit`).

https://desire2learn.atlassian.net/browse/QE-2218