### PR TITLE
Migrate unit tests from Sinon to node:test mock API

### DIFF
--- a/test/integration/report-validation.test.js
+++ b/test/integration/report-validation.test.js
@@ -14,6 +14,7 @@ import { testReportLatestPartial as testReportLatestPartialWebTestRunner } from 
 import { testReportLatestPartial as testReportLatestPartialWebdriverIO } from './data/validation/test-report-webdriverio.js';
 
 use(chaiSubset);
+
 const testContext = {
 	github: {
 		organization: 'TestOrganization',

--- a/test/unit/github.test.js
+++ b/test/unit/github.test.js
@@ -1,8 +1,9 @@
-import { afterEach, before, describe, it } from 'node:test';
+import { afterEach, describe, it } from 'node:test';
 import { getContext, hasContext } from '../../src/helpers/github.cjs';
-import { createSandbox } from 'sinon';
+import { env } from 'node:process';
 import { expect } from 'chai';
 
+const originalEnv = { ...env };
 const validContext = {
 	github: {
 		organization: 'TestOrganization',
@@ -17,22 +18,26 @@ const validContext = {
 	}
 };
 
+const setEnv = (values) => {
+	for (const key of Object.keys(env)) {
+		delete env[key];
+	}
+
+	Object.assign(env, values);
+};
+
 describe('github', () => {
-	let sandbox;
-
-	before(() => sandbox = createSandbox());
-
-	afterEach(() => sandbox.restore());
+	afterEach(() => setEnv(originalEnv));
 
 	describe('has context', () => {
 		it('false outside actions', () => {
-			sandbox.stub(process, 'env').value({});
+			setEnv({});
 
 			expect(hasContext()).to.be.false;
 		});
 
 		it('true in actions', () => {
-			sandbox.stub(process, 'env').value({ 'GITHUB_ACTIONS': '1' });
+			setEnv({ 'GITHUB_ACTIONS': '1' });
 
 			expect(hasContext()).to.be.true;
 		});
@@ -50,13 +55,13 @@ describe('github', () => {
 		};
 
 		it('throws outside actions', () => {
-			sandbox.stub(process, 'env').value({});
+			setEnv({});
 
 			expect(getContext).to.throw('GitHub context unavailable');
 		});
 
 		it('on pull request', () => {
-			sandbox.stub(process, 'env').value({
+			setEnv({
 				...commonEnvironment,
 				'GITHUB_HEAD_REF': 'test/branch'
 			});
@@ -67,7 +72,7 @@ describe('github', () => {
 		});
 
 		it('on branch', () => {
-			sandbox.stub(process, 'env').value({
+			setEnv({
 				...commonEnvironment,
 				'GITHUB_REF': 'test/branch'
 			});
@@ -78,7 +83,7 @@ describe('github', () => {
 		});
 
 		it('strips prefix', () => {
-			sandbox.stub(process, 'env').value({
+			setEnv({
 				...commonEnvironment,
 				'GITHUB_REF': 'refs/heads/test/branch'
 			});
@@ -89,7 +94,7 @@ describe('github', () => {
 		});
 
 		it('strips prefix (case-insensitive)', () => {
-			sandbox.stub(process, 'env').value({
+			setEnv({
 				...commonEnvironment,
 				'GITHUB_REF': 'Refs/Heads/test/branch'
 			});
@@ -100,7 +105,7 @@ describe('github', () => {
 		});
 
 		it('prefers head ref', () => {
-			sandbox.stub(process, 'env').value({
+			setEnv({
 				...commonEnvironment,
 				'GITHUB_HEAD_REF': 'pr/branch',
 				'GITHUB_REF': 'refs/heads/main'

--- a/test/unit/report-builder.test.js
+++ b/test/unit/report-builder.test.js
@@ -1,16 +1,16 @@
-import { afterEach, before, beforeEach, describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
 import chaiUuid from 'chai-uuid';
-import { createSandbox, match } from 'sinon';
 import { expect, use } from 'chai';
 import fs from 'node:fs';
 import { latestReportVersion } from '../../src/helpers/schema.cjs';
 import { ReportBuilder } from '../../src/helpers/report-builder.cjs';
 import { Report } from '../../src/helpers/report.cjs';
+
 const noopLogger = {
-	info() { },
-	warning() { },
-	error() { },
-	location() { }
+	info: () => { },
+	warning: () => { },
+	error: () => { },
+	location: () => { }
 };
 const testContext = {
 	github: {
@@ -25,6 +25,7 @@ const testContext = {
 		sha: '0000000000000000000000000000000000000000'
 	}
 };
+
 use(chaiUuid);
 
 const buildValidReport = (options = {}) => {
@@ -55,31 +56,26 @@ const buildValidReport = (options = {}) => {
 	return builder;
 };
 
-const configPathMatcher = match(
-	path => typeof path === 'string' &&
-		path.includes('d2l-test-reporting.config')
-);
+const configPathPredicate = (path) => typeof path === 'string' && path.includes('d2l-test-reporting.config');
 const testConfig = JSON.stringify({
 	type: 'unit',
 	tool: 'Test Reporting'
 });
 
 describe('report builder', () => {
-	let sandbox;
-	let readFileSyncStub;
-
-	before(() => {
-		sandbox = createSandbox();
-	});
-
 	beforeEach(() => {
-		readFileSyncStub = sandbox.stub(fs, 'readFileSync').callThrough();
-		readFileSyncStub
-			.withArgs(configPathMatcher)
-			.returns(testConfig);
+		const originalReadFileSync = fs.readFileSync;
+
+		mock.method(fs, 'readFileSync', (filePath) => {
+			if (configPathPredicate(filePath)) {
+				return testConfig;
+			}
+
+			return originalReadFileSync(filePath);
+		});
 	});
 
-	afterEach(() => sandbox.restore());
+	afterEach(() => mock.reset());
 
 	describe('constructor', () => {
 		it('throws with both output options', () => {
@@ -117,7 +113,7 @@ describe('report builder', () => {
 		it('produces loadable report', () => {
 			const builder = buildValidReport();
 
-			readFileSyncStub.returns(JSON.stringify(builder));
+			mock.method(fs, 'readFileSync', () => JSON.stringify(builder));
 
 			const report = new Report('./test-report.json', { context: testContext });
 
@@ -551,20 +547,19 @@ describe('report builder', () => {
 
 		describe('save', () => {
 			it('writes valid JSON', () => {
-				const spy = sandbox.spy();
+				const spy = mock.fn();
 				const builder = buildValidReport({ reportWriter: spy });
 
 				builder.save();
 
-				expect(spy.calledOnce).to.be.true;
+				expect(spy.mock.callCount()).to.eq(1);
 
-				const reportData = spy.firstCall.args[0];
-
+				const reportData = spy.mock.calls[0].arguments[0];
 				expect(() => JSON.parse(reportData)).to.not.throw();
 			});
 
 			it('logs error on failure', () => {
-				const errorSpy = sandbox.spy();
+				const errorSpy = mock.fn();
 				const logger = { ...noopLogger, error: errorSpy };
 				const builder = new ReportBuilder('mocha', logger, {
 					reportWriter: () => { throw new Error('write failed'); }
@@ -574,8 +569,8 @@ describe('report builder', () => {
 				builder.finalize();
 				builder.save();
 
-				expect(errorSpy.calledOnce).to.be.true;
-				expect(errorSpy.firstCall.args[0]).to.include('Failed to generate');
+				expect(errorSpy.mock.callCount()).to.eq(1);
+				expect(errorSpy.mock.calls[0].arguments[0]).to.include('Failed to generate');
 			});
 		});
 	});
@@ -594,9 +589,7 @@ describe('report builder', () => {
 				ignorePatterns: ['**/ignored/**']
 			});
 
-			readFileSyncStub
-				.withArgs(configPathMatcher)
-				.returns(config);
+			mock.method(fs, 'readFileSync', () => config);
 
 			const builder = new ReportBuilder('mocha', noopLogger, {
 				reportWriter: () => { },
@@ -613,9 +606,7 @@ describe('report builder', () => {
 				ignorePatterns: ['**/ignored/**']
 			});
 
-			readFileSyncStub
-				.withArgs(configPathMatcher)
-				.returns(config);
+			mock.method(fs, 'readFileSync', () => config);
 
 			const builder = new ReportBuilder('mocha', noopLogger, {
 				reportWriter: () => { },

--- a/test/unit/report-configuration.test.js
+++ b/test/unit/report-configuration.test.js
@@ -1,5 +1,4 @@
-import { afterEach, before, beforeEach, describe, it } from 'node:test';
-import { createSandbox } from 'sinon';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
 import { expect } from 'chai';
 import fs from 'node:fs';
 import { ReportConfiguration } from '../../src/helpers/report-configuration.cjs';
@@ -7,29 +6,26 @@ import { ReportConfiguration } from '../../src/helpers/report-configuration.cjs'
 const configPath = './d2l-test-reporting.config.json';
 
 describe('report configuration', () => {
-	let sandbox;
 	let logger;
-
-	before(() => sandbox = createSandbox());
 
 	beforeEach(() => {
 		logger = {
-			info: sandbox.spy(),
-			warning: sandbox.spy(),
-			error: sandbox.spy(),
-			location: sandbox.spy()
+			info: mock.fn(),
+			warning: mock.fn(),
+			error: mock.fn(),
+			location: mock.fn()
 		};
 	});
 
-	afterEach(() => sandbox.restore());
+	afterEach(() => mock.reset());
 
 	const loadConfig = (config) => {
-		sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(config));
+		mock.method(fs, 'readFileSync', () => JSON.stringify(config));
 
 		return new ReportConfiguration(configPath, logger);
 	};
 
-	const warningMessages = () => logger.warning.getCalls().map(call => call.args[0]);
+	const warningMessages = () => logger.warning.mock.calls.map(call => call.arguments[0]);
 
 	describe('legacy (v1, upgrades to v2)', () => {
 		describe('top-level', () => {
@@ -128,27 +124,27 @@ describe('report configuration', () => {
 			const config = loadConfig(input);
 
 			expect(config.toJSON()).to.deep.equal(input);
-			expect(logger.warning.called).to.be.false;
+			expect(logger.warning.mock.callCount()).to.eq(0);
 		});
 	});
 
 	describe('validation', () => {
 		describe('throws', () => {
 			it('for invalid config', () => {
-				sandbox.stub(fs, 'readFileSync').returns(JSON.stringify({}));
+				mock.method(fs, 'readFileSync', () => JSON.stringify({}));
 
 				expect(() => new ReportConfiguration(configPath, logger)).to.throw(/report configuration/);
 			});
 
 			it('when unparseable', () => {
-				sandbox.stub(fs, 'readFileSync').returns('not json');
+				mock.method(fs, 'readFileSync', () => 'not json');
 
 				expect(() => new ReportConfiguration(configPath, logger)).to.throw('Unable to read/parse');
 			});
 		});
 
 		it('empty without config file', () => {
-			sandbox.stub(fs, 'readFileSync').throws(new Error('ENOENT'));
+			mock.method(fs, 'readFileSync', () => { throw new Error('ENOENT'); });
 
 			const config = new ReportConfiguration(undefined, logger);
 
@@ -165,12 +161,12 @@ describe('report configuration', () => {
 
 		for (const logger of [null, undefined]) {
 			it(`uses when logger is \`${logger}\``, () => {
-				const warn = sandbox.stub(console, 'warn');
+				const warn = mock.method(console, 'warn', () => {});
 
-				sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(legacyConfig));
+				mock.method(fs, 'readFileSync', () => JSON.stringify(legacyConfig));
 
 				expect(() => new ReportConfiguration(configPath, logger)).to.not.throw();
-				expect(warn.calledWithMatch(/'experience' is no longer supported/)).to.be.true;
+				expect(warn.mock.calls.some(c => /'experience' is no longer supported/.test(c.arguments[0]))).to.be.true;
 			});
 		}
 	});

--- a/test/unit/report.test.js
+++ b/test/unit/report.test.js
@@ -1,5 +1,4 @@
-import { afterEach, before, describe, it } from 'node:test';
-import { createSandbox } from 'sinon';
+import { afterEach, describe, it, mock } from 'node:test';
 import { expect } from 'chai';
 import { flatten } from '../../src/helpers/object.cjs';
 import fs from 'node:fs';
@@ -406,18 +405,14 @@ const testReportOldV3ConfigOnly = {
 };
 
 describe('report', () => {
-	let sandbox;
-
-	before(() => sandbox = createSandbox());
-
-	afterEach(() => sandbox.restore());
+	afterEach(() => mock.reset());
 
 	describe(`legacy (v1, upgrades to v${latestReportVersion})`, () => {
 		const testReportCurrentVersion = 1;
 
 		describe('construction', () => {
 			it('don\'t override context', () => {
-				sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportV1Full));
+				mock.method(fs, 'readFileSync', () => JSON.stringify(testReportV1Full));
 
 				let report;
 
@@ -433,7 +428,7 @@ describe('report', () => {
 
 			describe('full report', () => {
 				it('override context', () => {
-					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportV1Full));
+					mock.method(fs, 'readFileSync', () => JSON.stringify(testReportV1Full));
 
 					const reportOptions = {
 						context: testContextOther,
@@ -452,7 +447,7 @@ describe('report', () => {
 				});
 
 				it('inject context if needed', () => {
-					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportV1Full));
+					mock.method(fs, 'readFileSync', () => JSON.stringify(testReportV1Full));
 
 					const reportOptions = {
 						context: testContextOther
@@ -472,7 +467,7 @@ describe('report', () => {
 
 			describe('no context', () => {
 				it('override context', () => {
-					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportV1NoContext));
+					mock.method(fs, 'readFileSync', () => JSON.stringify(testReportV1NoContext));
 
 					const reportOptions = {
 						context: testContextOther,
@@ -491,7 +486,7 @@ describe('report', () => {
 				});
 
 				it('inject context if needed', () => {
-					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportV1NoContext));
+					mock.method(fs, 'readFileSync', () => JSON.stringify(testReportV1NoContext));
 
 					const reportOptions = {
 						context: testContextOther
@@ -511,7 +506,7 @@ describe('report', () => {
 
 			describe('partial context', () => {
 				it('override context', () => {
-					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportV1PartialContext));
+					mock.method(fs, 'readFileSync', () => JSON.stringify(testReportV1PartialContext));
 
 					const reportOptions = {
 						context: testContextOther,
@@ -530,7 +525,7 @@ describe('report', () => {
 				});
 
 				it('inject context if needed', () => {
-					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportV1PartialContext));
+					mock.method(fs, 'readFileSync', () => JSON.stringify(testReportV1PartialContext));
 
 					const reportOptions = {
 						context: testContextOther
@@ -555,7 +550,7 @@ describe('report', () => {
 
 		describe('construction', () => {
 			it('don\'t override context', () => {
-				sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportV2Full));
+				mock.method(fs, 'readFileSync', () => JSON.stringify(testReportV2Full));
 
 				let report;
 
@@ -571,7 +566,7 @@ describe('report', () => {
 
 			describe('full report', () => {
 				it('override context', () => {
-					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportV2Full));
+					mock.method(fs, 'readFileSync', () => JSON.stringify(testReportV2Full));
 
 					const reportOptions = {
 						context: testContextOther,
@@ -590,7 +585,7 @@ describe('report', () => {
 				});
 
 				it('inject context if needed', () => {
-					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportV2Full));
+					mock.method(fs, 'readFileSync', () => JSON.stringify(testReportV2Full));
 
 					const reportOptions = {
 						context: testContextOther
@@ -610,7 +605,7 @@ describe('report', () => {
 
 			describe('no context', () => {
 				it('override context', () => {
-					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportV2NoContext));
+					mock.method(fs, 'readFileSync', () => JSON.stringify(testReportV2NoContext));
 
 					const reportOptions = {
 						context: testContextOther,
@@ -629,7 +624,7 @@ describe('report', () => {
 				});
 
 				it('inject context if needed', () => {
-					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportV2NoContext));
+					mock.method(fs, 'readFileSync', () => JSON.stringify(testReportV2NoContext));
 
 					const reportOptions = {
 						context: testContextOther
@@ -649,7 +644,7 @@ describe('report', () => {
 
 			describe('partial context', () => {
 				it('override context', () => {
-					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportV2PartialContext));
+					mock.method(fs, 'readFileSync', () => JSON.stringify(testReportV2PartialContext));
 
 					const reportOptions = {
 						context: testContextOther,
@@ -668,7 +663,7 @@ describe('report', () => {
 				});
 
 				it('inject context if needed', () => {
-					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportV2PartialContext));
+					mock.method(fs, 'readFileSync', () => JSON.stringify(testReportV2PartialContext));
 
 					const reportOptions = {
 						context: testContextOther
@@ -691,7 +686,7 @@ describe('report', () => {
 	describe(`latest (v${latestReportVersion}, no upgrade)`, () => {
 		describe('construction', () => {
 			it('don\'t override context', () => {
-				sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportLatestFull));
+				mock.method(fs, 'readFileSync', () => JSON.stringify(testReportLatestFull));
 
 				let report;
 
@@ -707,7 +702,7 @@ describe('report', () => {
 
 			describe('full report', () => {
 				it('override context', () => {
-					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportLatestFull));
+					mock.method(fs, 'readFileSync', () => JSON.stringify(testReportLatestFull));
 
 					const reportOptions = {
 						context: testContextOther,
@@ -726,7 +721,7 @@ describe('report', () => {
 				});
 
 				it('inject context if needed', () => {
-					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportLatestFull));
+					mock.method(fs, 'readFileSync', () => JSON.stringify(testReportLatestFull));
 
 					const reportOptions = { context: testContextOther };
 					let report;
@@ -744,7 +739,7 @@ describe('report', () => {
 
 			describe('no context', () => {
 				it('override context', () => {
-					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportLatestNoContext));
+					mock.method(fs, 'readFileSync', () => JSON.stringify(testReportLatestNoContext));
 
 					const reportOptions = {
 						context: testContextOther,
@@ -763,7 +758,7 @@ describe('report', () => {
 				});
 
 				it('inject context if needed', () => {
-					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportLatestNoContext));
+					mock.method(fs, 'readFileSync', () => JSON.stringify(testReportLatestNoContext));
 
 					const reportOptions = { context: testContextOther };
 					let report;
@@ -781,7 +776,7 @@ describe('report', () => {
 
 			describe('partial context', () => {
 				it('override context', () => {
-					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportLatestPartialContext));
+					mock.method(fs, 'readFileSync', () => JSON.stringify(testReportLatestPartialContext));
 
 					const reportOptions = {
 						context: testContextOther,
@@ -800,7 +795,7 @@ describe('report', () => {
 				});
 
 				it('inject context if needed', () => {
-					sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportLatestPartialContext));
+					mock.method(fs, 'readFileSync', () => JSON.stringify(testReportLatestPartialContext));
 
 					const reportOptions = { context: testContextOther };
 					let report;
@@ -820,7 +815,7 @@ describe('report', () => {
 
 	describe(`legacy (old v3, cleans to v${latestReportVersion})`, () => {
 		it('cleans config to configuration', () => {
-			sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportOldV3ConfigOnly));
+			mock.method(fs, 'readFileSync', () => JSON.stringify(testReportOldV3ConfigOnly));
 
 			let report;
 
@@ -833,7 +828,7 @@ describe('report', () => {
 		});
 
 		it('cleans flat taxonomy to nested taxonomy', () => {
-			sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportOldV3Full));
+			mock.method(fs, 'readFileSync', () => JSON.stringify(testReportOldV3Full));
 
 			let report;
 
@@ -852,7 +847,7 @@ describe('report', () => {
 		});
 
 		it('strips experience', () => {
-			sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportOldV3Full));
+			mock.method(fs, 'readFileSync', () => JSON.stringify(testReportOldV3Full));
 
 			let report;
 
@@ -866,7 +861,7 @@ describe('report', () => {
 		});
 
 		it('cleans all old v3 properties at once', () => {
-			sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportOldV3Full));
+			mock.method(fs, 'readFileSync', () => JSON.stringify(testReportOldV3Full));
 
 			let report;
 
@@ -879,7 +874,7 @@ describe('report', () => {
 		});
 
 		it('preserves already-clean v3 report', () => {
-			sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(testReportLatestFull));
+			mock.method(fs, 'readFileSync', () => JSON.stringify(testReportLatestFull));
 
 			let report;
 
@@ -897,7 +892,7 @@ describe('report', () => {
 			}));
 			const mixedReport = { ...testReportLatestFull, details: mixedDetails };
 
-			sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(mixedReport));
+			mock.method(fs, 'readFileSync', () => JSON.stringify(mixedReport));
 
 			let report;
 
@@ -922,7 +917,7 @@ describe('report', () => {
 			}));
 			const mixedReport = { ...testReportLatestFull, details: mixedDetails };
 
-			sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(mixedReport));
+			mock.method(fs, 'readFileSync', () => JSON.stringify(mixedReport));
 
 			let report;
 

--- a/test/unit/system.test.js
+++ b/test/unit/system.test.js
@@ -1,38 +1,36 @@
-import { afterEach, before, beforeEach, describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
 import { getNow, getNowISOString, getOperatingSystemType, makeRelativeFilePath } from '../../src/helpers/system.cjs';
-import { createSandbox } from 'sinon';
 import { expect } from 'chai';
 import os from 'node:os';
 import { join } from 'node:path';
 
 describe('system', () => {
-	let sandbox;
-
-	before(() => sandbox = createSandbox());
-
-	afterEach(() => sandbox.restore());
+	afterEach(() => {
+		mock.reset();
+		mock.timers.reset();
+	});
 
 	describe('os type', () => {
 		it('linux', () => {
-			sandbox.stub(os, 'type').returns('Linux');
+			mock.method(os, 'type', () => 'Linux');
 
 			expect(getOperatingSystemType()).to.eq('linux');
 		});
 
 		it('macos', () => {
-			sandbox.stub(os, 'type').returns('Darwin');
+			mock.method(os, 'type', () => 'Darwin');
 
 			expect(getOperatingSystemType()).to.eq('macos');
 		});
 
 		it('windows', () => {
-			sandbox.stub(os, 'type').returns('Windows_NT');
+			mock.method(os, 'type', () => 'Windows_NT');
 
 			expect(getOperatingSystemType()).to.eq('windows');
 		});
 
 		it('unknown throws', () => {
-			sandbox.stub(os, 'type').returns('FreeBSD');
+			mock.method(os, 'type', () => 'FreeBSD');
 
 			expect(getOperatingSystemType).to.throw('Unknown operating system');
 		});
@@ -55,7 +53,7 @@ describe('system', () => {
 	describe('now', () => {
 		const fakeNow = 1234567890;
 
-		beforeEach(() => sandbox.useFakeTimers(fakeNow));
+		beforeEach(() => mock.timers.enable({ apis: ['Date'], now: fakeNow }));
 
 		it('date', () => {
 			expect(getNow().getTime()).to.be.greaterThan(fakeNow);


### PR DESCRIPTION
Replaces Sinon (`createSandbox`, `stub`, `spy`, `match`, `useFakeTimers`) in the unit tests with the native `node:test` mock API (`mock.method`, `mock.fn`, `mock.timers`), and swaps the `github.test.js` `process.env` stub for a direct env snapshot/restore helper. `sinon` remains a dependency since the integration fixtures still use it.

Helps reduce dependencies but we can't get rid of mocha since I need to test it.

https://desire2learn.atlassian.net/browse/QE-2218