### PR TITLE
fix: add node:test fake timers coverage to integration fixtures

### DIFF
--- a/src/reporters/playwright.js
+++ b/src/reporters/playwright.js
@@ -1,6 +1,7 @@
 import { createRequire } from 'node:module';
 import { colors } from 'playwright-core/lib/utilsBundle';
 import { escapeSpecialCharacters } from '../helpers/strings.cjs';
+import { getNow, getNowISOString } from '../helpers/system.cjs';
 
 const require = createRequire(import.meta.url);
 
@@ -51,6 +52,7 @@ export default class Reporter {
 	#logger;
 	#options;
 	#report;
+	#runStarted;
 
 	constructor(options = {}) {
 		this.#options = options;
@@ -63,6 +65,7 @@ export default class Reporter {
 			return;
 		}
 
+		this.#runStarted = getNow();
 		this.#logger = new PlaywrightLogger();
 
 		try {
@@ -95,13 +98,16 @@ export default class Reporter {
 		const { startTime, retry, status, duration } = result;
 		const project = test.parent.project();
 		const name = makeTestName(test);
+		const started = startTime < this.#runStarted ?
+			getNowISOString() :
+			startTime.toISOString();
 		const detail = this.#report
 			.getDetail(id)
 			.setName(name)
 			.setLocationFile(file)
 			.setLocationLine(line)
 			.setLocationColumn(column)
-			.setStarted(startTime)
+			.setStarted(started)
 			.setTimeout(Math.round(timeout))
 			.addDuration(Math.round(duration));
 		const isRetry = retry !== 0;
@@ -133,7 +139,7 @@ export default class Reporter {
 		const { startTime, duration, status } = result;
 		const summary = this.#report
 			.getSummary()
-			.setStarted(startTime)
+			.setStarted(startTime.toISOString())
 			.setDurationTotal(Math.round(duration));
 
 		if (status === 'passed') {

--- a/test/integration/data/tests/jest/fake-timers.test.cjs
+++ b/test/integration/data/tests/jest/fake-timers.test.cjs
@@ -1,4 +1,5 @@
 const { createSandbox } = require('sinon');
+const { mock } = require('node:test');
 
 const realSetTimeout = setTimeout;
 
@@ -9,17 +10,29 @@ const delay = (ms = 50) => {
 const fakeNow = 1234567890;
 
 describe('fake timers', () => {
-	let sandbox;
+	describe('sinon', () => {
+		let sandbox;
 
-	beforeAll(() => {
-		sandbox = createSandbox();
+		beforeAll(() => {
+			sandbox = createSandbox();
 
-		sandbox.useFakeTimers(fakeNow);
+			sandbox.useFakeTimers(fakeNow);
+		});
+
+		afterAll(() => sandbox.restore());
+
+		test('passed', async() => { await delay(); });
+
+		test('failed', () => { throw new Error('fail'); });
 	});
 
-	afterAll(() => sandbox.restore());
+	describe('node', () => {
+		beforeAll(() => mock.timers.enable({ apis: ['Date'], now: fakeNow }));
 
-	test('passed', async() => { await delay(); });
+		afterAll(() => mock.timers.reset());
 
-	test('failed', () => { throw new Error('fail'); });
+		test('passed', async() => { await delay(); });
+
+		test('failed', () => { throw new Error('fail'); });
+	});
 });

--- a/test/integration/data/tests/mocha/fake-timers.test.js
+++ b/test/integration/data/tests/mocha/fake-timers.test.js
@@ -1,4 +1,5 @@
 import { createSandbox } from 'sinon';
+import { mock } from 'node:test';
 
 const realSetTimeout = setTimeout;
 
@@ -9,17 +10,29 @@ const delay = (ms = 50) => {
 const fakeNow = 1234567890;
 
 describe('fake timers', () => {
-	let sandbox;
+	describe('sinon', () => {
+		let sandbox;
 
-	before(() => {
-		sandbox = createSandbox();
+		before(() => {
+			sandbox = createSandbox();
 
-		sandbox.useFakeTimers(fakeNow);
+			sandbox.useFakeTimers(fakeNow);
+		});
+
+		after(() => sandbox.restore());
+
+		it('passed', async() => { await delay(); });
+
+		it('failed', () => { throw new Error('fail'); });
 	});
 
-	after(() => sandbox.restore());
+	describe('node', () => {
+		before(() => mock.timers.enable({ apis: ['Date'], now: fakeNow }));
 
-	it('passed', async() => { await delay(); });
+		after(() => mock.timers.reset());
 
-	it('failed', () => { throw new Error('fail'); });
+		it('passed', async() => { await delay(); });
+
+		it('failed', () => { throw new Error('fail'); });
+	});
 });

--- a/test/integration/data/tests/node/fake-timers.test.js
+++ b/test/integration/data/tests/node/fake-timers.test.js
@@ -1,4 +1,4 @@
-import { after, before, describe, it } from 'node:test';
+import { after, before, describe, it, mock } from 'node:test';
 import { createSandbox } from 'sinon';
 
 const delay = (ms = 50) => {
@@ -8,17 +8,29 @@ const delay = (ms = 50) => {
 const fakeNow = 1234567890;
 
 describe('fake timers', () => {
-	let sandbox;
+	describe('sinon', () => {
+		let sandbox;
 
-	before(() => {
-		sandbox = createSandbox();
+		before(() => {
+			sandbox = createSandbox();
 
-		sandbox.useFakeTimers({ now: fakeNow, toFake: ['Date'] });
+			sandbox.useFakeTimers({ now: fakeNow, toFake: ['Date'] });
+		});
+
+		after(() => sandbox.restore());
+
+		it('passed', async() => { await delay(); });
+
+		it('failed', () => { throw new Error('fail'); });
 	});
 
-	after(() => sandbox.restore());
+	describe('node', () => {
+		before(() => mock.timers.enable({ apis: ['Date'], now: fakeNow }));
 
-	it('passed', async() => { await delay(); });
+		after(() => mock.timers.reset());
 
-	it('failed', () => { throw new Error('fail'); });
+		it('passed', async() => { await delay(); });
+
+		it('failed', () => { throw new Error('fail'); });
+	});
 });

--- a/test/integration/data/tests/playwright/fake-timers.test.js
+++ b/test/integration/data/tests/playwright/fake-timers.test.js
@@ -1,4 +1,5 @@
 import { createSandbox } from 'sinon';
+import { mock } from 'node:test';
 import { test } from '@playwright/test';
 
 const realSetTimeout = setTimeout;
@@ -10,17 +11,29 @@ const delay = (ms = 50) => {
 const fakeNow = 1234567890;
 
 test.describe('fake timers', () => {
-	let sandbox;
+	test.describe('sinon', () => {
+		let sandbox;
 
-	test.beforeAll(() => {
-		sandbox = createSandbox();
+		test.beforeAll(() => {
+			sandbox = createSandbox();
 
-		sandbox.useFakeTimers({ now: fakeNow, shouldClearNativeTimers: true });
+			sandbox.useFakeTimers({ now: fakeNow, shouldClearNativeTimers: true });
+		});
+
+		test.afterAll(() => sandbox.restore());
+
+		test('passed', async() => { await delay(); });
+
+		test('failed', () => { throw new Error('fail'); });
 	});
 
-	test.afterAll(() => sandbox.restore());
+	test.describe('node', () => {
+		test.beforeAll(() => mock.timers.enable({ apis: ['Date'], now: fakeNow }));
 
-	test('passed', async() => { await delay(); });
+		test.afterAll(() => mock.timers.reset());
 
-	test('failed', () => { throw new Error('fail'); });
+		test('passed', async() => { await delay(); });
+
+		test('failed', () => { throw new Error('fail'); });
+	});
 });

--- a/test/integration/data/tests/webdriverio/fake-timers.test.js
+++ b/test/integration/data/tests/webdriverio/fake-timers.test.js
@@ -1,4 +1,5 @@
 import { createSandbox } from 'sinon';
+import { mock } from 'node:test';
 
 const realSetTimeout = setTimeout;
 
@@ -9,17 +10,29 @@ const delay = (ms = 50) => {
 const fakeNow = 1234567890;
 
 describe('fake timers', () => {
-	let sandbox;
+	describe('sinon', () => {
+		let sandbox;
 
-	before(() => {
-		sandbox = createSandbox();
+		before(() => {
+			sandbox = createSandbox();
 
-		sandbox.useFakeTimers(fakeNow);
+			sandbox.useFakeTimers(fakeNow);
+		});
+
+		after(() => sandbox.restore());
+
+		it('passed', async() => { await delay(); });
+
+		it('failed', () => { throw new Error('fail'); });
 	});
 
-	after(() => sandbox.restore());
+	describe('node', () => {
+		before(() => mock.timers.enable({ apis: ['Date'], now: fakeNow }));
 
-	it('passed', async() => { await delay(); });
+		after(() => mock.timers.reset());
 
-	it('failed', () => { throw new Error('fail'); });
+		it('passed', async() => { await delay(); });
+
+		it('failed', () => { throw new Error('fail'); });
+	});
 });

--- a/test/integration/data/validation/test-report-jest.js
+++ b/test/integration/data/validation/test-report-jest.js
@@ -5,7 +5,7 @@ export const testReportLatestPartial = {
 	summary: {
 		status: 'failed',
 		framework: 'jest',
-		count: { passed: 8, failed: 11, skipped: 2, flaky: 0 }
+		count: { passed: 9, failed: 12, skipped: 2, flaky: 0 }
 	},
 	details: [{
 		name: 'hook failures > before all failure > test with before all failure',
@@ -29,14 +29,28 @@ export const testReportLatestPartial = {
 		taxonomy: { tool: 'Jest Hook Failures Test Reporting', type: 'ui' },
 		retries: 3
 	}, {
-		name: 'fake timers > passed',
+		name: 'fake timers > sinon > passed',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/jest/fake-timers.test.cjs' },
 		configuration: { timeout: 5000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
-		name: 'fake timers > failed',
+		name: 'fake timers > sinon > failed',
+		status: 'failed',
+		location: { file: 'test/integration/data/tests/jest/fake-timers.test.cjs' },
+		configuration: { timeout: 5000 },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 3
+	}, {
+		name: 'fake timers > node > passed',
+		status: 'passed',
+		location: { file: 'test/integration/data/tests/jest/fake-timers.test.cjs' },
+		configuration: { timeout: 5000 },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 0
+	}, {
+		name: 'fake timers > node > failed',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/jest/fake-timers.test.cjs' },
 		configuration: { timeout: 5000 },

--- a/test/integration/data/validation/test-report-mocha.js
+++ b/test/integration/data/validation/test-report-mocha.js
@@ -5,7 +5,7 @@ export const testReportLatestPartial = {
 	summary: {
 		status: 'failed',
 		framework: 'mocha',
-		count: { passed: 10, failed: 7, skipped: 2, flaky: 2 }
+		count: { passed: 11, failed: 8, skipped: 2, flaky: 2 }
 	},
 	details: [{
 		name: 'custom timeout > suite level timeout',
@@ -22,14 +22,28 @@ export const testReportLatestPartial = {
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
-		name: 'fake timers > passed',
+		name: 'fake timers > sinon > passed',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/mocha/fake-timers.test.js' },
 		configuration: { timeout: 2000 },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
-		name: 'fake timers > failed',
+		name: 'fake timers > sinon > failed',
+		status: 'failed',
+		location: { file: 'test/integration/data/tests/mocha/fake-timers.test.js' },
+		configuration: { timeout: 2000 },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 3
+	}, {
+		name: 'fake timers > node > passed',
+		status: 'passed',
+		location: { file: 'test/integration/data/tests/mocha/fake-timers.test.js' },
+		configuration: { timeout: 2000 },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 0
+	}, {
+		name: 'fake timers > node > failed',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/mocha/fake-timers.test.js' },
 		configuration: { timeout: 2000 },

--- a/test/integration/data/validation/test-report-node.js
+++ b/test/integration/data/validation/test-report-node.js
@@ -5,7 +5,7 @@ export const testReportLatestPartial = {
 	summary: {
 		status: 'failed',
 		framework: 'node',
-		count: { passed: 8, failed: 11, skipped: 2, flaky: 0 }
+		count: { passed: 9, failed: 12, skipped: 2, flaky: 0 }
 	},
 	details: [{
 		name: 'custom timeout > suite level timeout',
@@ -20,13 +20,25 @@ export const testReportLatestPartial = {
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
-		name: 'fake timers > passed',
+		name: 'fake timers > sinon > passed',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/node/fake-timers.test.js' },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
-		name: 'fake timers > failed',
+		name: 'fake timers > sinon > failed',
+		status: 'failed',
+		location: { file: 'test/integration/data/tests/node/fake-timers.test.js' },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 0
+	}, {
+		name: 'fake timers > node > passed',
+		status: 'passed',
+		location: { file: 'test/integration/data/tests/node/fake-timers.test.js' },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 0
+	}, {
+		name: 'fake timers > node > failed',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/node/fake-timers.test.js' },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },

--- a/test/integration/data/validation/test-report-playwright.js
+++ b/test/integration/data/validation/test-report-playwright.js
@@ -5,7 +5,7 @@ export const testReportLatestPartial = {
 	summary: {
 		status: 'failed',
 		framework: 'playwright',
-		count: { passed: 24, failed: 33, skipped: 21, flaky: 6 }
+		count: { passed: 27, failed: 36, skipped: 21, flaky: 6 }
 	},
 	details: [{
 		name: '[chromium] > hook failures > before each failure > test with before each failure',
@@ -44,12 +44,24 @@ export const testReportLatestPartial = {
 		taxonomy: { tool: 'Playwright Hook Failures Test Reporting', type: 'ui' },
 		retries: 3
 	}, {
-		name: '[chromium] > fake timers > failed',
+		name: '[chromium] > fake timers > sinon > failed',
 		status: 'failed',
 		location: {
 			file: 'test/integration/data/tests/playwright/fake-timers.test.js',
-			line: 25,
-			column: 2
+			line: 27,
+			column: 3
+		},
+		browser: 'chromium',
+		configuration: { timeout: 30000 },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 3
+	}, {
+		name: '[chromium] > fake timers > node > failed',
+		status: 'failed',
+		location: {
+			file: 'test/integration/data/tests/playwright/fake-timers.test.js',
+			line: 37,
+			column: 3
 		},
 		browser: 'chromium',
 		configuration: { timeout: 30000 },
@@ -92,12 +104,24 @@ export const testReportLatestPartial = {
 		taxonomy: { tool: 'Playwright Hook Failures Test Reporting', type: 'ui' },
 		retries: 3
 	}, {
-		name: '[chromium] > fake timers > passed',
+		name: '[chromium] > fake timers > sinon > passed',
 		status: 'passed',
 		location: {
 			file: 'test/integration/data/tests/playwright/fake-timers.test.js',
-			line: 23,
-			column: 2
+			line: 25,
+			column: 3
+		},
+		browser: 'chromium',
+		configuration: { timeout: 30000 },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 0
+	}, {
+		name: '[chromium] > fake timers > node > passed',
+		status: 'passed',
+		location: {
+			file: 'test/integration/data/tests/playwright/fake-timers.test.js',
+			line: 35,
+			column: 3
 		},
 		browser: 'chromium',
 		configuration: { timeout: 30000 },
@@ -308,12 +332,24 @@ export const testReportLatestPartial = {
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
-		name: '[firefox] > fake timers > failed',
+		name: '[firefox] > fake timers > sinon > failed',
 		status: 'failed',
 		location: {
 			file: 'test/integration/data/tests/playwright/fake-timers.test.js',
-			line: 25,
-			column: 2
+			line: 27,
+			column: 3
+		},
+		browser: 'firefox',
+		configuration: { timeout: 30000 },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 3
+	}, {
+		name: '[firefox] > fake timers > node > failed',
+		status: 'failed',
+		location: {
+			file: 'test/integration/data/tests/playwright/fake-timers.test.js',
+			line: 37,
+			column: 3
 		},
 		browser: 'firefox',
 		configuration: { timeout: 30000 },
@@ -380,12 +416,24 @@ export const testReportLatestPartial = {
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 3
 	}, {
-		name: '[firefox] > fake timers > passed',
+		name: '[firefox] > fake timers > sinon > passed',
 		status: 'passed',
 		location: {
 			file: 'test/integration/data/tests/playwright/fake-timers.test.js',
-			line: 23,
-			column: 2
+			line: 25,
+			column: 3
+		},
+		browser: 'firefox',
+		configuration: { timeout: 30000 },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 0
+	}, {
+		name: '[firefox] > fake timers > node > passed',
+		status: 'passed',
+		location: {
+			file: 'test/integration/data/tests/playwright/fake-timers.test.js',
+			line: 35,
+			column: 3
 		},
 		browser: 'firefox',
 		configuration: { timeout: 30000 },
@@ -644,12 +692,24 @@ export const testReportLatestPartial = {
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
-		name: '[webkit] > fake timers > passed',
+		name: '[webkit] > fake timers > sinon > passed',
 		status: 'passed',
 		location: {
 			file: 'test/integration/data/tests/playwright/fake-timers.test.js',
-			line: 23,
-			column: 2
+			line: 25,
+			column: 3
+		},
+		browser: 'webkit',
+		configuration: { timeout: 30000 },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 0
+	}, {
+		name: '[webkit] > fake timers > node > passed',
+		status: 'passed',
+		location: {
+			file: 'test/integration/data/tests/playwright/fake-timers.test.js',
+			line: 35,
+			column: 3
 		},
 		browser: 'webkit',
 		configuration: { timeout: 30000 },
@@ -704,12 +764,24 @@ export const testReportLatestPartial = {
 		taxonomy: { tool: 'Playwright 1 Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
-		name: '[webkit] > fake timers > failed',
+		name: '[webkit] > fake timers > sinon > failed',
 		status: 'failed',
 		location: {
 			file: 'test/integration/data/tests/playwright/fake-timers.test.js',
-			line: 25,
-			column: 2
+			line: 27,
+			column: 3
+		},
+		browser: 'webkit',
+		configuration: { timeout: 30000 },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 3
+	}, {
+		name: '[webkit] > fake timers > node > failed',
+		status: 'failed',
+		location: {
+			file: 'test/integration/data/tests/playwright/fake-timers.test.js',
+			line: 37,
+			column: 3
 		},
 		browser: 'webkit',
 		configuration: { timeout: 30000 },

--- a/test/integration/data/validation/test-report-webdriverio.js
+++ b/test/integration/data/validation/test-report-webdriverio.js
@@ -9,7 +9,7 @@ export const testReportLatestPartial = {
 	summary: {
 		status: 'failed',
 		framework: 'webdriverio',
-		count: { passed: 10, failed: 7, skipped: 2, flaky: 2 }
+		count: { passed: 11, failed: 8, skipped: 2, flaky: 2 }
 	},
 	details: [{
 		name: `[${platform}] > taxonomy overrides > passed`,
@@ -131,14 +131,28 @@ export const testReportLatestPartial = {
 		taxonomy: { tool: 'WebdriverIO Hook Failures Test Reporting', type: 'ui' },
 		retries: 0
 	}, {
-		name: `[${platform}] > fake timers > passed`,
+		name: `[${platform}] > fake timers > sinon > passed`,
 		browser: 'chrome',
 		status: 'passed',
 		location: { file: 'test/integration/data/tests/webdriverio/fake-timers.test.js' },
 		taxonomy: { tool: 'Test Reporting', type: 'integration' },
 		retries: 0
 	}, {
-		name: `[${platform}] > fake timers > failed`,
+		name: `[${platform}] > fake timers > sinon > failed`,
+		browser: 'chrome',
+		status: 'failed',
+		location: { file: 'test/integration/data/tests/webdriverio/fake-timers.test.js' },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 3
+	}, {
+		name: `[${platform}] > fake timers > node > passed`,
+		browser: 'chrome',
+		status: 'passed',
+		location: { file: 'test/integration/data/tests/webdriverio/fake-timers.test.js' },
+		taxonomy: { tool: 'Test Reporting', type: 'integration' },
+		retries: 0
+	}, {
+		name: `[${platform}] > fake timers > node > failed`,
 		browser: 'chrome',
 		status: 'failed',
 		location: { file: 'test/integration/data/tests/webdriverio/fake-timers.test.js' },


### PR DESCRIPTION
Adds `node:test` `mock.timers` coverage alongside the existing Sinon fake-timers tests in the integration fixtures (`node`, `jest`, `mocha`, `playwright`, `webdriverio`), reorganized into `sinon` and `node` sub-suites with the validation golden files updated to match. `web-test-runner` is excluded since it runs in a browser where `node:test` is unavailable.

This also fixes a fringe case with playwright test running and timer faking.

https://desire2learn.atlassian.net/browse/QE-2045