### PR TITLE
fix: use webdriverio runner start time for report summary

### DIFF
--- a/src/reporters/webdriverio.cjs
+++ b/src/reporters/webdriverio.cjs
@@ -133,7 +133,7 @@ class WebdriverIO extends WDIOReporter {
 	}
 
 	onRunnerStart(runner) {
-		const { cid } = runner;
+		const { cid, start } = runner;
 		const { reportPath, reportConfigurationPath, verbose } = this.#options;
 		const dir = dirname(reportPath);
 		const ext = extname(reportPath);
@@ -154,10 +154,12 @@ class WebdriverIO extends WDIOReporter {
 			return;
 		}
 
+		const started = start ? start.toISOString() : getNowISOString();
+
 		this.#report
 			.getSummary()
 			.addContext()
-			.setStarted(getNowISOString());
+			.setStarted(started);
 	}
 
 	onSuiteStart(suite) {


### PR DESCRIPTION
Source the webdriverio report summary `started` from the framework's `RunnerStats.start` (falling back to `getNowISOString()` when absent), matching how the `jest`, `mocha`, and `web-test-runner` reporters already derive the run start time.

https://desire2learn.atlassian.net/browse/QE-2218