### PR TITLE
Run lint steps in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,11 @@ jobs:
           d2l-registry-token: ${{ secrets.D2L_PACKAGE_REGISTRY_AUTH_TOKEN }}
       - name: Install dependencies
         run: npm ci
-      - name: Lint (ESLint)
-        run: npm run lint:eslint
-      - name: Lint (EditorConfig)
-        run: npm run lint:editorconfig
+      - parallel:
+        - name: Lint (ESLint)
+          run: npm run lint:eslint
+        - name: Lint (EditorConfig)
+          run: npm run lint:editorconfig
   licenses:
     name: Check Licenses
     timeout-minutes: 5


### PR DESCRIPTION
Runs independent lint checks concurrently to reduce CI duration.

QE-2293