### PR TITLE
QE-2363: Ignore eslint-plugin-mocha v12 updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,8 @@ updates:
         update-types: ['version-update:semver-patch']
       - dependency-name: eslint
         versions: '>= 10'
+      - dependency-name: eslint-plugin-mocha
+        versions: '>= 12'
     groups:
       eslint:
         dependency-type: development


### PR DESCRIPTION
Updates `.github/dependabot.yml` to ignore `eslint-plugin-mocha` versions 12 and newer, keeping the dependency on supported major version 11.

[QE-2363](https://desire2learn.atlassian.net/browse/QE-2363)

[QE-2363]: https://desire2learn.atlassian.net/browse/QE-2363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ