### PR TITLE
Split JavaScript and npm pull request labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     directory: /
     labels:
       - dependencies
+      - npm
     schedule:
       interval: weekly
       time: '08:00'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,3 +14,9 @@ javascript:
   - changed-files:
     - any-glob-to-any-file:
       - '**/*.{js,cjs}'
+npm:
+  - changed-files:
+    - any-glob-to-any-file:
+      - .npmrc
+      - package-lock.json
+      - package.json

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -27,7 +27,10 @@
   color: e4e669
 - name: javascript
   description: Pull requests that update JavaScript code
-  color: 168700
+  color: f1e05a
+- name: npm
+  description: Pull requests that update npm packages or configuration
+  color: cb3837
 - name: question
   description: Further information is requested
   color: d876e3


### PR DESCRIPTION
Adds a dedicated npm label for tracked package manifests, lockfiles, and npm configuration while keeping JavaScript labeling source-only. Updates npm Dependabot labeling and changes JavaScript to GitHub Linguist's standard yellow.

[QE-2403](https://desire2learn.atlassian.net/browse/QE-2403)

[QE-2403]: https://desire2learn.atlassian.net/browse/QE-2403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ